### PR TITLE
[feat] issue-#50: accountBook에 unclassified, classified 구분

### DIFF
--- a/src/main/java/swm/backstage/movis/domain/accout_book/AccountBook.java
+++ b/src/main/java/swm/backstage/movis/domain/accout_book/AccountBook.java
@@ -3,7 +3,6 @@ package swm.backstage.movis.domain.accout_book;
 
 import jakarta.persistence.*;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 import swm.backstage.movis.domain.club.Club;
 import swm.backstage.movis.domain.event.Event;
 
@@ -20,13 +19,17 @@ public class AccountBook {
     private Long id;
 
     private Long balance;
-    private Long totalDeposit;
-    private Long totalWithdrawal;
+    private Long classifiedDeposit;
+    private Long unClassifiedDeposit;
+    private Long classifiedWithdrawal;
+    private Long unClassifiedWithdrawal;
 
     public AccountBook() {
         this.balance = 0L;
-        this.totalDeposit = 0L;
-        this.totalWithdrawal = 0L;
+        this.classifiedDeposit = 0L;
+        this.unClassifiedDeposit = 0L;
+        this.classifiedWithdrawal = 0L;
+        this.unClassifiedWithdrawal = 0L;
     }
 
     @OneToOne(fetch = FetchType.LAZY)
@@ -42,16 +45,25 @@ public class AccountBook {
 
     public AccountBook(Long balance) {
         this.balance = balance;
-
     }
 
-    public void updateBalanceWithFee(Long paidAmount) {
-        this.balance += paidAmount;
-        this.totalDeposit += paidAmount;
+    public void updateClassifiedDeposit(Long paidAmount) {
+        this.classifiedDeposit += paidAmount;
     }
 
-    public void updateBalanceWithEventBill(Long paidAmount) {
+    public void updateUnClassifiedDeposit(Long paidAmount) {
+        this.unClassifiedDeposit += paidAmount;
+    }
+
+    public void updateUnClassifiedWithdrawal(Long paidAmount) {
+        this.unClassifiedWithdrawal += paidAmount;
+    }
+
+    public void updateBalance(Long paidAmount) {
         this.balance += paidAmount;
-        this.totalWithdrawal += paidAmount;
+    }
+
+    public void updateClassifiedWithdrawal(Long amount) {
+        this.classifiedWithdrawal +=amount;
     }
 }

--- a/src/main/java/swm/backstage/movis/domain/event_bill/service/EventBillService.java
+++ b/src/main/java/swm/backstage/movis/domain/event_bill/service/EventBillService.java
@@ -39,6 +39,9 @@ public class EventBillService {
     @Transactional
     public void createEventBill(EventBillCreateReqDto eventBillCreateReqDto){
         EventBill eventBill = eventBillRepository.save(new EventBill(UUID.randomUUID().toString(), eventBillCreateReqDto,clubService.getClubByUuId(eventBillCreateReqDto.getClubId())));
+        AccountBook accountBook = accountBookService.getAccountBookByClubId(eventBillCreateReqDto.getClubId());
+        accountBook.updateUnClassifiedWithdrawal(eventBillCreateReqDto.getAmount());
+        accountBook.updateBalance(eventBillCreateReqDto.getAmount());
         transactionHistoryService.saveTransactionHistory(TransactionHistoryCreateDto.fromEventBill(eventBill));
     }
 
@@ -51,7 +54,8 @@ public class EventBillService {
         AccountBook accountBook = accountBookService.getAccountBookByClubId(eventBillUpdateReqDto.getClubId());
         EventBill eventBill = getEventBillByUuid(eventBillId);
         Event event = eventService.getEventByUuid(eventBillUpdateReqDto.getEventId());
-        accountBook.updateBalanceWithEventBill(eventBill.getAmount());
+        accountBook.updateClassifiedWithdrawal(eventBill.getAmount());
+        accountBook.updateUnClassifiedWithdrawal(-eventBill.getAmount());
         event.updateBalance(eventBill.getAmount());
         eventBill.setEvent(event);
         transactionHistoryService.updateTransactionHistory(new TransactionHistoryUpdateDto(eventBillId,eventBill.getPayName(),event));

--- a/src/main/java/swm/backstage/movis/domain/transaction_history/dto/TransactionHistoryGetPagingListResDto.java
+++ b/src/main/java/swm/backstage/movis/domain/transaction_history/dto/TransactionHistoryGetPagingListResDto.java
@@ -15,8 +15,10 @@ public class TransactionHistoryGetPagingListResDto {
     List<TransactionHistoryGetElementResDto> feeElements;
     private Boolean isLast;
     private Long totalBalance;
-    private Long totalDeposit;
-    private Long totalWithdraw;
+    private Long totalClassifiedDeposit;
+    private Long totalUnClassifiedDeposit;
+    private Long totalClassifiedWithdrawal;
+    private Long totalUnClassifiedWithdrawal;
 
     public TransactionHistoryGetPagingListResDto(List<TransactionHistory> feeList, Boolean isLast, AccountBook accountBook) {
         this.isLast = isLast;
@@ -25,8 +27,10 @@ public class TransactionHistoryGetPagingListResDto {
                 .toList();
         if(accountBook!=null) {
             this.totalBalance = accountBook.getBalance();
-            this.totalDeposit = accountBook.getTotalDeposit();
-            this.totalWithdraw = accountBook.getTotalWithdrawal();
+            this.totalClassifiedDeposit = accountBook.getClassifiedDeposit();
+            this.totalUnClassifiedDeposit = accountBook.getUnClassifiedDeposit();
+            this.totalClassifiedWithdrawal = accountBook.getClassifiedWithdrawal();
+            this.totalUnClassifiedWithdrawal = accountBook.getUnClassifiedWithdrawal();
         }
     }
 }

--- a/src/main/java/swm/backstage/movis/domain/transaction_history/service/TransactionHistoryService.java
+++ b/src/main/java/swm/backstage/movis/domain/transaction_history/service/TransactionHistoryService.java
@@ -60,7 +60,7 @@ public class TransactionHistoryService {
         Club club = clubService.getClubByUuId(clubId);
         List<TransactionHistory> transactionHistoryListList;
 
-        System.out.println("second");
+
         if (lastId.equals("first")) {
             transactionHistoryListList = transactionHistoryRepository.getFirstPageByClub(club.getId(), lastPaidAt, size + 1);
         } else {


### PR DESCRIPTION
AccountBook에 
 classifiedDeposit, unClassifiedDeposit, classifiedWithdrawal, unClassifiedWithdrawal
추가

1. Fee (입금)

- > 입금 내역 발생시 분류여부와 상관없이 accountBook balance 추가
      - 미분류시 balance 업데이트
      - 자동 분류시 balance 업데이트
      - 수동 분류는 update 금지
- > 입금내역 발생시 미분류 되면 accout book에 미분류 입금 수정 unclassifiedDepoist 증가
- > 입금내역 발생시 분류 되면 account book에 분류 입금 수정  
      - 자동 분류시 classifiedDeposit 만 증가
      - 수동 분류시 unClassifiedDeposit 감소후 classifiedDeposit 증가


2. 출금 (EventBill Entity)
- > EventBillService에 createEventBill을 진행할 때 accoutBook unClassifiedWithdrawl 증가
      - unClassifiedWithdrawal 업데이트
      - accountBook의  Balance 값 업데이트 

- > EventBIllService 수동 분류에 accountBook classifiedWithdrawal 증가 및 unClassifiedDrawal 감소

