### PR TITLE
[feat] issue-#53: Qualifier 어노테이션 추가

### DIFF
--- a/src/main/java/swm/backstage/movis/global/config/SecurityConfig.java
+++ b/src/main/java/swm/backstage/movis/global/config/SecurityConfig.java
@@ -1,6 +1,7 @@
 package swm.backstage.movis.global.config;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.AuthenticationManager;
@@ -23,13 +24,22 @@ import swm.backstage.movis.domain.auth.utils.JwtUtil;
 
 @Configuration
 @EnableWebSecurity
-@RequiredArgsConstructor
 public class SecurityConfig {
 
     private final JwtUtil jwtUtil;
     private final AuthTokenService authTokenService;
     private final CorsConfigurationSource corsConfigurationSource;
     private final HandlerExceptionResolver handlerExceptionResolver;
+
+    public SecurityConfig(JwtUtil jwtUtil,
+                          AuthTokenService authTokenService,
+                          @Qualifier("corsConfigurationSource") CorsConfigurationSource corsConfigurationSource,
+                          @Qualifier("handlerExceptionResolver") HandlerExceptionResolver handlerExceptionResolver) {
+        this.jwtUtil = jwtUtil;
+        this.authTokenService = authTokenService;
+        this.corsConfigurationSource = corsConfigurationSource;
+        this.handlerExceptionResolver = handlerExceptionResolver;
+    }
 
     @Bean
     public AuthenticationManager authenticationManager(AuthenticationConfiguration configuration) throws Exception {


### PR DESCRIPTION
## 이슈
- [Build시 Bean 등록 에러 발생](https://github.com/swm-backstage/movis-backend/issues/53)

## 구현 기능
SecurityConfig의 생성자에서 corsConfigurationSource, handlerExceptionResolver에 Qualifier 어노테이션을 적용함으로써 특정 Bean 명시

## 작업 시간
0.5h