### PR TITLE
[feat] issue-#52: 입출금 수동 입력 기능 추가

### DIFF
--- a/src/main/java/swm/backstage/movis/domain/alert/service/AlertManager.java
+++ b/src/main/java/swm/backstage/movis/domain/alert/service/AlertManager.java
@@ -39,7 +39,7 @@ public class AlertManager {
                 dto.getCash(),
                 dto.getCreatedAt()
         );
-        feeService.createFee(newFeeReqDto);
+        feeService.createFeeByAlert(newFeeReqDto);
     }
 
     public void alertToEventBill(AlertGetRequestDTO dto){

--- a/src/main/java/swm/backstage/movis/domain/event_bill/EventBill.java
+++ b/src/main/java/swm/backstage/movis/domain/event_bill/EventBill.java
@@ -9,6 +9,7 @@ import org.springframework.data.annotation.CreatedDate;
 import swm.backstage.movis.domain.club.Club;
 import swm.backstage.movis.domain.event.Event;
 import swm.backstage.movis.domain.event_bill.dto.EventBillCreateReqDto;
+import swm.backstage.movis.domain.event_bill.dto.EventBillInputReqDto;
 
 import java.time.LocalDateTime;
 
@@ -64,6 +65,16 @@ public class EventBill {
         this.club = club;
         this.paidAt = eventBillCreateReqDto.getPaidAt();
         this.isDeleted = false;
+    }
+
+    public EventBill(String string, EventBillInputReqDto dto, Club club, Event event) {
+        this.uuid = string;
+        this.payName = dto.getName();
+        this.amount = dto.getPaidAmount();
+        this.club = club;
+        this.event = event;
+        this.isDeleted = false;
+        this.paidAt = dto.getPaidAt();
     }
 
     public void setEvent(Event event) {

--- a/src/main/java/swm/backstage/movis/domain/event_bill/controller/EventBillController.java
+++ b/src/main/java/swm/backstage/movis/domain/event_bill/controller/EventBillController.java
@@ -5,6 +5,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 import swm.backstage.movis.domain.event_bill.dto.*;
 import swm.backstage.movis.domain.event_bill.service.EventBillService;
+import swm.backstage.movis.domain.fee.dto.FeeInputReqDto;
 
 import java.time.LocalDateTime;
 
@@ -13,6 +14,14 @@ import java.time.LocalDateTime;
 @RequestMapping("/api/v1/eventBill")
 public class EventBillController {
     private final EventBillService eventBillService;
+    /**
+     * 회비 수동 입력
+     * */
+    @PostMapping("/input")
+    public void createEventBillByInput(@RequestParam("eventId") String eventId,
+                                       @RequestBody EventBillInputReqDto dto){
+        eventBillService.createEventBillByInput(eventId,dto);
+    }
     /**
      * 지출 내역 추가 (알림으로)
      * */

--- a/src/main/java/swm/backstage/movis/domain/event_bill/dto/EventBillInputReqDto.java
+++ b/src/main/java/swm/backstage/movis/domain/event_bill/dto/EventBillInputReqDto.java
@@ -1,0 +1,17 @@
+package swm.backstage.movis.domain.event_bill.dto;
+
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor
+public class EventBillInputReqDto {
+    private Long paidAmount;
+    private LocalDateTime paidAt;
+    private String name;
+    private String explanation;
+    private String image;
+}

--- a/src/main/java/swm/backstage/movis/domain/fee/Fee.java
+++ b/src/main/java/swm/backstage/movis/domain/fee/Fee.java
@@ -8,6 +8,7 @@ import lombok.Setter;
 import swm.backstage.movis.domain.club.Club;
 import swm.backstage.movis.domain.event.Event;
 import swm.backstage.movis.domain.event_member.EventMember;
+import swm.backstage.movis.domain.fee.dto.FeeInputReqDto;
 import swm.backstage.movis.domain.fee.dto.FeeReqDto;
 
 import java.time.LocalDateTime;
@@ -47,6 +48,8 @@ public class Fee {
     @JoinColumn(name = "event_member_id")
     private EventMember eventMember;
 
+
+
     public Fee(String uuid, FeeReqDto feeReqDto, Club club) {
         this.uuid = uuid;
         this.paidAmount = feeReqDto.getPaidAmount();
@@ -63,6 +66,17 @@ public class Fee {
         this.club = club;
         this.eventMember = eventMember;
         this.event = eventMember.getEvent();
+    }
+
+    public Fee(String uuid, FeeInputReqDto feeInputReqDto, Club club, Event event, EventMember eventMember) {
+        this.uuid = uuid;
+        this.paidAmount = feeInputReqDto.getPaidAmount();
+        this.paidAt = feeInputReqDto.getPaidAt();
+        this.name = feeInputReqDto.getName();
+        this.explanation = feeInputReqDto.getExplanation();
+        this.club = club;
+        this.event = event;
+        this.eventMember = eventMember;
     }
 
     public void updateBlankElement(EventMember eventMember, FeeReqDto feeReqDto) {

--- a/src/main/java/swm/backstage/movis/domain/fee/controller/FeeController.java
+++ b/src/main/java/swm/backstage/movis/domain/fee/controller/FeeController.java
@@ -5,10 +5,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.*;
 import swm.backstage.movis.domain.event_bill.dto.EventBIllCreateExplanationReqDto;
 import swm.backstage.movis.domain.event_bill.dto.EventBillGetResDto;
-import swm.backstage.movis.domain.fee.dto.FeeCreateExplanationReqDto;
-import swm.backstage.movis.domain.fee.dto.FeeGetResDto;
-import swm.backstage.movis.domain.fee.dto.FeeReqDto;
-import swm.backstage.movis.domain.fee.dto.FeeGetPagingListResDto;
+import swm.backstage.movis.domain.fee.dto.*;
 import swm.backstage.movis.domain.fee.service.FeeService;
 
 import java.time.LocalDateTime;
@@ -21,11 +18,19 @@ import java.time.LocalDateTime;
 public class FeeController {
     private final FeeService feeService;
     /**
-     * 회비 생성
+     * 회비 수동 입력
+     * */
+    @PostMapping("/input")
+    public void createFeeByInput(@RequestParam("eventId") String eventId,
+                                 @RequestBody FeeInputReqDto feeInputReqDto){
+        feeService.createFeeByInput(eventId,feeInputReqDto);
+    }
+    /**
+     * 회비 생성 (알림용)
      * */
     @PostMapping()
-    public void createFee(@RequestBody FeeReqDto feeReqDto){
-        feeService.createFee(feeReqDto);
+    public void createFeeByAlert(@RequestBody FeeReqDto feeReqDto){
+        feeService.createFeeByAlert(feeReqDto);
     }
     /**
      * 회비 수동 분류

--- a/src/main/java/swm/backstage/movis/domain/fee/dto/FeeInputReqDto.java
+++ b/src/main/java/swm/backstage/movis/domain/fee/dto/FeeInputReqDto.java
@@ -1,0 +1,18 @@
+package swm.backstage.movis.domain.fee.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor
+@ToString
+public class FeeInputReqDto {
+    private String eventMemberId;
+    private Long paidAmount;
+    private LocalDateTime paidAt;
+    private String name;
+    private String explanation;
+}


### PR DESCRIPTION
Fee (입금)


-  회비 수동입력 API 구현
   < Request Body >
   eventMemberId ( 없으면 null )
   금액 입력 ( amount )
   납부자 명 ( name )  
   납부 시간
   설명 ( 없으면 null )

   로직 순서  
   1. 이벤트에 속한 member리스트에서 한명 선택하기 (납부자 처리). 만약, 회장 이름으로 넣고 싶은거면 null로 전달하기
   2. 금액, 납부시간, 설명 입력하기
   3. 납부자 명은 eventMember를 골랐으면 해당하는 이름을 넣어주면 되고 eventMembe가 null이면 직접 입력하기
   4. fee 저장하고 transactionHistory에도 추가하기
   5. accountBook 값도 변경하기 


EventBill ( 출금 )

-  출금 수동입력 API 구현
    < Reqeust Body >
    금액 ( amount )
    납부자 명 ( name )
    납부 시간 ( paidAt )
    설명 ( 없으면 null )
    영수증 사진 ( 없으면 null )

    1. EventBill을 생성하며 accountBook의 withDrawal을 업데이트 및 balance 업데이트