### PR TITLE
[feat] issue-#56: event 수정, 삭제 기능 추가

### DIFF
--- a/src/main/java/swm/backstage/movis/domain/event/Event.java
+++ b/src/main/java/swm/backstage/movis/domain/event/Event.java
@@ -7,8 +7,10 @@ import lombok.NoArgsConstructor;
 import swm.backstage.movis.domain.accout_book.AccountBook;
 import swm.backstage.movis.domain.club.Club;
 import swm.backstage.movis.domain.event.dto.EventCreateReqDto;
+import swm.backstage.movis.domain.event.dto.EventUpdateReqDto;
 import swm.backstage.movis.domain.event_bill.EventBill;
 import swm.backstage.movis.domain.event_member.EventMember;
+import swm.backstage.movis.domain.fee.Fee;
 import swm.backstage.movis.domain.transaction_history.TransactionHistory;
 
 import java.time.LocalDate;
@@ -51,6 +53,9 @@ public class Event {
     @OneToMany(mappedBy = "event", fetch = FetchType.LAZY)
     private List<TransactionHistory> transactionHistorys = new ArrayList<>();
 
+    @OneToMany(mappedBy = "event", fetch = FetchType.LAZY)
+    private List<Fee> fees = new ArrayList<>();
+
     @Column(name="balance")
     private Long balance;
 
@@ -60,7 +65,8 @@ public class Event {
     @Column(name="payment_deadline")
     private LocalDate paymentDeadline;
 
-
+    @Column(name="is_deleted")
+    private Boolean isDeleted;
 
     public Event(String uuid, EventCreateReqDto eventCreateReqDto, Club club, AccountBook accountBook) {
         this.uuid = uuid;
@@ -68,6 +74,7 @@ public class Event {
         this.club =club;
         this.accountBook = accountBook;
         this.balance = 0L;
+        this.isDeleted = Boolean.FALSE;
         if(eventCreateReqDto.getGatherFeeInfo() == null){
             this.totalPaymentAmount = 0L;
         }
@@ -76,14 +83,19 @@ public class Event {
             this.paymentDeadline = eventCreateReqDto.getGatherFeeInfo().getPaymentDeadline();
         }
     }
-
     public void updateBalance(Long balance) {
         this.balance +=  balance;
-
     }
-
     public void updateGatherFeeInfo(Long totalPaymentAmount, LocalDate paymentDeadline) {
         this.totalPaymentAmount = totalPaymentAmount;
         this.paymentDeadline = paymentDeadline;
+    }
+    public void updateIsDeleted(Boolean isDeleted) {
+        this.isDeleted = isDeleted;
+    }
+    public void updateEvent(EventUpdateReqDto eventUpdateReqDto) {
+        this.name = eventUpdateReqDto.getName();
+        this.totalPaymentAmount = eventUpdateReqDto.getTotalPaymentAmount();
+        this.paymentDeadline = eventUpdateReqDto.getPaymentDeadline();
     }
 }

--- a/src/main/java/swm/backstage/movis/domain/event/controller/EventController.java
+++ b/src/main/java/swm/backstage/movis/domain/event/controller/EventController.java
@@ -46,4 +46,21 @@ public class EventController {
                                                          @RequestParam("now") LocalDate now) {
         return new EventGetFundingListResDto(eventService.getCollectingMoneyEventList(clubId,now));
     }
+    /**
+     * 이벤트 수정
+     * */
+    @PatchMapping()
+    public EventGetDto updateEvent(@RequestParam(name = "eventId") String eventId,
+                            @RequestBody EventUpdateReqDto eventUpdateReqDto) {
+        return new EventGetDto(eventService.updateEvent(eventId,eventUpdateReqDto));
+    }
+    /**
+     * 이벤트 삭제
+     * */
+    @DeleteMapping()
+    public void deleteEvent(@RequestParam(name = "clubId") String clubId,
+                            @RequestParam(name = "eventId") String eventId) {
+        eventService.deleteEvent(clubId,eventId);
+    }
+
 }

--- a/src/main/java/swm/backstage/movis/domain/event/dto/EventUpdateReqDto.java
+++ b/src/main/java/swm/backstage/movis/domain/event/dto/EventUpdateReqDto.java
@@ -1,0 +1,14 @@
+package swm.backstage.movis.domain.event.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Getter
+@NoArgsConstructor
+public class EventUpdateReqDto {
+    private String name;
+    private LocalDate paymentDeadline;
+    private Long totalPaymentAmount;
+}

--- a/src/main/java/swm/backstage/movis/domain/event/service/EventService.java
+++ b/src/main/java/swm/backstage/movis/domain/event/service/EventService.java
@@ -5,13 +5,22 @@ package swm.backstage.movis.domain.event.service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import swm.backstage.movis.domain.accout_book.AccountBook;
+import swm.backstage.movis.domain.accout_book.service.AccountBookService;
 import swm.backstage.movis.domain.club.Club;
 import swm.backstage.movis.domain.club.service.ClubService;
 import swm.backstage.movis.domain.event.Event;
 import swm.backstage.movis.domain.event.dto.EventCreateReqDto;
 import swm.backstage.movis.domain.event.dto.EventGatherFeeReqDto;
 import swm.backstage.movis.domain.event.dto.EventGetPagingListResDto;
+import swm.backstage.movis.domain.event.dto.EventUpdateReqDto;
 import swm.backstage.movis.domain.event.repository.EventRepository;
+import swm.backstage.movis.domain.event_bill.EventBill;
+import swm.backstage.movis.domain.event_bill.service.EventBillManager;
+import swm.backstage.movis.domain.fee.Fee;
+import swm.backstage.movis.domain.fee.service.FeeManager;
+import swm.backstage.movis.domain.fee.service.FeeService;
+import swm.backstage.movis.domain.transaction_history.service.TransactionHistoryManager;
 import swm.backstage.movis.global.error.ErrorCode;
 import swm.backstage.movis.global.error.exception.BaseException;
 
@@ -25,6 +34,10 @@ public class EventService {
 
     private final EventRepository eventRepository;
     private final ClubService clubService;
+    private final AccountBookService accountBookService;
+    private final FeeManager feeManager;
+    private final EventBillManager eventBillManager;
+    private final TransactionHistoryManager transactionHistoryManager;
 
     @Transactional
     public Event createEvent(EventCreateReqDto eventCreateReqDto) {
@@ -91,4 +104,42 @@ public class EventService {
         Event event = getEventByUuid(eventId);
         event.updateGatherFeeInfo(eventGatherFeeReqDto.getTotalPaymentAmount(),eventGatherFeeReqDto.getPaymentDeadline());
     }
+
+    @Transactional
+    public Event updateEvent(String eventId, EventUpdateReqDto eventUpdateReqDto) {
+        Event event = getEventByUuid(eventId);
+        event.updateEvent(eventUpdateReqDto);
+        return event;
+    }
+
+    @Transactional
+    public void deleteEvent(String clubId, String eventId) {
+
+        //1. lock 걸고
+        AccountBook accountBook = accountBookService.getAccountBookByClubId(clubId);
+        Event event = getEventByUuid(eventId);
+        event.updateIsDeleted(Boolean.TRUE);
+        accountBook.updateBalance(-event.getBalance());
+
+        //2. deposit 관련 수정
+        long deposit = 0;
+        feeManager.updateIsDeleted(event.getId());
+        for(Fee fee : event.getFees()){
+           deposit = deposit + fee.getPaidAmount();
+        }
+        accountBook.updateClassifiedDeposit(-deposit);
+
+        //3. eventBill 수정
+        eventBillManager.updateIsDeleted(event.getId());
+        long withdraw = 0L;
+        for(EventBill eventBill : event.getEventBills()){
+            withdraw = withdraw + eventBill.getAmount();
+        }
+        accountBook.updateClassifiedWithdrawal(-withdraw);
+
+        //4. transactionHistory 수정
+        transactionHistoryManager.updateIsDeleted(event.getId());
+    }
+
+
 }

--- a/src/main/java/swm/backstage/movis/domain/event_bill/EventBill.java
+++ b/src/main/java/swm/backstage/movis/domain/event_bill/EventBill.java
@@ -5,11 +5,11 @@ import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
-import org.springframework.data.annotation.CreatedDate;
 import swm.backstage.movis.domain.club.Club;
 import swm.backstage.movis.domain.event.Event;
 import swm.backstage.movis.domain.event_bill.dto.EventBillCreateReqDto;
 import swm.backstage.movis.domain.event_bill.dto.EventBillInputReqDto;
+import swm.backstage.movis.global.common.DateTimeField;
 
 import java.time.LocalDateTime;
 
@@ -20,7 +20,7 @@ import java.time.LocalDateTime;
 })
 @NoArgsConstructor
 @Getter
-public class EventBill {
+public class EventBill extends DateTimeField {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -36,9 +36,6 @@ public class EventBill {
     private String payName;
 
     private LocalDateTime paidAt;
-
-    @CreatedDate
-    private LocalDateTime createdAt;
 
     @Column(name = "image", length = 500)
     private String image;
@@ -79,5 +76,9 @@ public class EventBill {
 
     public void setEvent(Event event) {
         this.event = event;
+    }
+
+    public void updateIsDeleted(Boolean isDeleted) {
+        this.isDeleted = isDeleted;
     }
 }

--- a/src/main/java/swm/backstage/movis/domain/event_bill/controller/EventBillController.java
+++ b/src/main/java/swm/backstage/movis/domain/event_bill/controller/EventBillController.java
@@ -1,11 +1,10 @@
 package swm.backstage.movis.domain.event_bill.controller;
 
-import jakarta.servlet.http.HttpServletResponse;
+
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 import swm.backstage.movis.domain.event_bill.dto.*;
 import swm.backstage.movis.domain.event_bill.service.EventBillService;
-import swm.backstage.movis.domain.fee.dto.FeeInputReqDto;
 
 import java.time.LocalDateTime;
 

--- a/src/main/java/swm/backstage/movis/domain/event_bill/repository/EventBillRepository.java
+++ b/src/main/java/swm/backstage/movis/domain/event_bill/repository/EventBillRepository.java
@@ -1,6 +1,7 @@
 package swm.backstage.movis.domain.event_bill.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import swm.backstage.movis.domain.event_bill.EventBill;
@@ -32,4 +33,11 @@ public interface EventBillRepository extends JpaRepository<EventBill, Long> {
                                 @Param("lastPaidAt") LocalDateTime lastPaidAt,
                                 @Param("lastId") Long lastId,
                                 @Param("size") int size);
+
+    @Modifying
+    @Query("UPDATE EventBill e " +
+            "SET e.isDeleted = :status " +
+            "WHERE e.event.id = :eventId ")
+    int updateIsDeletedByEventId(@Param("status") Boolean status,
+                                 @Param("eventId") Long eventId);
 }

--- a/src/main/java/swm/backstage/movis/domain/event_bill/service/EventBillManager.java
+++ b/src/main/java/swm/backstage/movis/domain/event_bill/service/EventBillManager.java
@@ -1,0 +1,21 @@
+package swm.backstage.movis.domain.event_bill.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import swm.backstage.movis.domain.event_bill.repository.EventBillRepository;
+
+@Service
+@RequiredArgsConstructor
+public class EventBillManager {
+
+    private final EventBillRepository eventBillRepository;
+    /**
+     * 출금 여러개 isDeleted 수정
+     * */
+    @Transactional
+    public int updateIsDeleted(Long eventId){
+        return eventBillRepository.updateIsDeletedByEventId(Boolean.TRUE,eventId);
+    }
+
+}

--- a/src/main/java/swm/backstage/movis/domain/event_bill/service/EventBillService.java
+++ b/src/main/java/swm/backstage/movis/domain/event_bill/service/EventBillService.java
@@ -41,7 +41,8 @@ public class EventBillService {
         EventBill eventBill = eventBillRepository.save(new EventBill(UUID.randomUUID().toString(), dto, event.getClub(), event));
         accountBook.updateBalance(dto.getPaidAmount());
         accountBook.updateClassifiedWithdrawal(dto.getPaidAmount());
-        transactionHistoryService.saveTransactionHistory(TransactionHistoryCreateDto.fromEventBill(eventBill));
+        event.updateBalance(dto.getPaidAmount());
+        transactionHistoryService.saveTransactionHistory(TransactionHistoryCreateDto.fromEventBill(eventBill,Boolean.TRUE));
     }
     /**
      * 지출 내역 추가 (알림)
@@ -52,7 +53,7 @@ public class EventBillService {
         AccountBook accountBook = accountBookService.getAccountBookByClubId(eventBillCreateReqDto.getClubId());
         accountBook.updateUnClassifiedWithdrawal(eventBillCreateReqDto.getAmount());
         accountBook.updateBalance(eventBillCreateReqDto.getAmount());
-        transactionHistoryService.saveTransactionHistory(TransactionHistoryCreateDto.fromEventBill(eventBill));
+        transactionHistoryService.saveTransactionHistory(TransactionHistoryCreateDto.fromEventBill(eventBill, Boolean.FALSE));
     }
 
     public EventBill getEventBillByUuid(String eventBillId) {

--- a/src/main/java/swm/backstage/movis/domain/fee/Fee.java
+++ b/src/main/java/swm/backstage/movis/domain/fee/Fee.java
@@ -31,6 +31,7 @@ public class Fee {
     private Long paidAmount;
     private LocalDateTime paidAt;
     private String name;
+    private Boolean isDeleted;
 
     @Setter
     @Column(length = 100)
@@ -56,6 +57,7 @@ public class Fee {
         this.paidAt = feeReqDto.getPaidAt();
         this.name = feeReqDto.getName();
         this.club = club;
+        this.isDeleted = false;
     }
 
     public Fee(String uuid, FeeReqDto feeReqDto, Club club, EventMember eventMember) {
@@ -66,6 +68,7 @@ public class Fee {
         this.club = club;
         this.eventMember = eventMember;
         this.event = eventMember.getEvent();
+        this.isDeleted = false;
     }
 
     public Fee(String uuid, FeeInputReqDto feeInputReqDto, Club club, Event event, EventMember eventMember) {
@@ -77,12 +80,17 @@ public class Fee {
         this.club = club;
         this.event = event;
         this.eventMember = eventMember;
+        this.isDeleted = false;
     }
 
     public void updateBlankElement(EventMember eventMember, FeeReqDto feeReqDto) {
         this.eventMember = eventMember;
         this.event = eventMember.getEvent();
         this.name = feeReqDto.getName();
+    }
+
+    public void updateIsDeleted(Boolean isDeleted){
+        this.isDeleted = isDeleted;
     }
 }
 

--- a/src/main/java/swm/backstage/movis/domain/fee/repository/FeeRepository.java
+++ b/src/main/java/swm/backstage/movis/domain/fee/repository/FeeRepository.java
@@ -1,6 +1,7 @@
 package swm.backstage.movis.domain.fee.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import swm.backstage.movis.domain.fee.Fee;
@@ -34,4 +35,11 @@ public interface FeeRepository extends JpaRepository<Fee, Long> {
                                             @Param("lastPaidAt") LocalDateTime lastPaidAt,
                                             @Param("lastId") Long lastId,
                                             @Param("size") int size);
+
+    @Modifying
+    @Query("UPDATE Fee f " +
+            "SET f.isDeleted = :status " +
+            "WHERE f.event.id = :eventId ")
+    int updateIsDeletedByEventId(@Param("status") Boolean status,
+                                 @Param("eventId") Long eventId);
 }

--- a/src/main/java/swm/backstage/movis/domain/fee/service/FeeManager.java
+++ b/src/main/java/swm/backstage/movis/domain/fee/service/FeeManager.java
@@ -1,0 +1,21 @@
+package swm.backstage.movis.domain.fee.service;
+
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import swm.backstage.movis.domain.fee.repository.FeeRepository;
+
+@Service
+@RequiredArgsConstructor
+public class FeeManager {
+
+    private final FeeRepository feeRepository;
+    /**
+     * 입금 여러개 isDeleted 수정
+     * */
+    @Transactional
+    public int updateIsDeleted(Long eventId){
+        return feeRepository.updateIsDeletedByEventId(Boolean.TRUE,eventId);
+    }
+}

--- a/src/main/java/swm/backstage/movis/domain/fee/service/FeeService.java
+++ b/src/main/java/swm/backstage/movis/domain/fee/service/FeeService.java
@@ -145,4 +145,11 @@ public class FeeService {
         fee.setExplanation(reqDto.getExplanation());
         return fee;
     }
+    /**
+     * 입금 여러개 isDeleted 수정
+     * */
+    @Transactional
+    public int updateIsDeleted(Long eventId){
+        return feeRepository.updateIsDeletedByEventId(Boolean.TRUE,eventId);
+    }
 }

--- a/src/main/java/swm/backstage/movis/domain/transaction_history/TransactionHistory.java
+++ b/src/main/java/swm/backstage/movis/domain/transaction_history/TransactionHistory.java
@@ -33,6 +33,7 @@ public class TransactionHistory {
     private Long amount;
     private LocalDateTime paidAt;
     private Boolean isClassified;
+    private Boolean isDeleted;
 
     @Enumerated(EnumType.STRING)
     private TransactionStatus status;
@@ -55,11 +56,15 @@ public class TransactionHistory {
         this.paidAt = dto.getPaidAt();
         this.isClassified = dto.getIsClassified();
         this.status = dto.getStatus();
+        this.isDeleted = Boolean.FALSE;
     }
     public void updateTransactionHistory(Event event, String name){
         this.event = event;
         this.name = name;
         this.isClassified = Boolean.TRUE;
+    }
+    public void updateIsDeleted(Boolean isDeleted){
+        this.isDeleted = isDeleted;
     }
 }
 

--- a/src/main/java/swm/backstage/movis/domain/transaction_history/dto/TransactionHistoryCreateDto.java
+++ b/src/main/java/swm/backstage/movis/domain/transaction_history/dto/TransactionHistoryCreateDto.java
@@ -35,7 +35,7 @@ public class TransactionHistoryCreateDto {
     }
 
 
-    public static TransactionHistoryCreateDto fromEventBill(EventBill eventBill) {
+    public static TransactionHistoryCreateDto fromEventBill(EventBill eventBill, Boolean isClassified) {
         return new TransactionHistoryCreateDto(
                 eventBill.getClub(),
                 eventBill.getEvent(),
@@ -44,7 +44,7 @@ public class TransactionHistoryCreateDto {
                 eventBill.getAmount(),
                 eventBill.getPaidAt(),
                 TransactionStatus.BILL,
-                Boolean.FALSE);
+                isClassified);
     }
     public static TransactionHistoryCreateDto fromFee(Fee fee, Boolean isClassified) {
         return new TransactionHistoryCreateDto(

--- a/src/main/java/swm/backstage/movis/domain/transaction_history/repository/TransactionHistoryRepository.java
+++ b/src/main/java/swm/backstage/movis/domain/transaction_history/repository/TransactionHistoryRepository.java
@@ -2,6 +2,7 @@ package swm.backstage.movis.domain.transaction_history.repository;
 
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import swm.backstage.movis.domain.transaction_history.TransactionHistory;
@@ -56,7 +57,15 @@ public interface TransactionHistoryRepository extends JpaRepository<TransactionH
                                                 @Param("lastId") Long lastId,
                                                 @Param("size") int size);
 
+    @Modifying
+    @Query("UPDATE TransactionHistory t " +
+            "SET t.isDeleted = :status " +
+            "WHERE t.event.id = :eventId ")
+    int updateIsDeletedByEventId(@Param("status") Boolean status,
+                                 @Param("eventId") Long eventId);
+
     Optional<TransactionHistory> findByElementUuid(String elementUuid);
     List<TransactionHistory> findAllByClubUuidAndIsClassifiedOrderByPaidAtDesc(String clubId, boolean isClassified);
     Long countByClubUuidAndIsClassified(String clubUuid, boolean isClassified);
+
 }

--- a/src/main/java/swm/backstage/movis/domain/transaction_history/service/TransactionHistoryManager.java
+++ b/src/main/java/swm/backstage/movis/domain/transaction_history/service/TransactionHistoryManager.java
@@ -1,0 +1,21 @@
+package swm.backstage.movis.domain.transaction_history.service;
+
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import swm.backstage.movis.domain.transaction_history.repository.TransactionHistoryRepository;
+
+@Service
+@RequiredArgsConstructor
+public class TransactionHistoryManager {
+
+    private final TransactionHistoryRepository transactionHistoryRepository;
+    /**
+     * 입금 여러개 isDeleted 수정
+     * */
+    @Transactional
+    public int updateIsDeleted(Long eventId){
+        return transactionHistoryRepository.updateIsDeletedByEventId(Boolean.TRUE,eventId);
+    }
+}


### PR DESCRIPTION
## 1. 내용

### 이벤트 삭제 기능

-> isDeleted 필드로 관리하고 이벤트를 삭제하게 되면 이벤트에 속한 입출금 내역을 같이 삭제해 줘야함

-> 같이 삭제하게 되면 입금 (Fee), 출금 ( event bill) , 거래내역 ( transaction_history) 3개의 요소 모두 삭제해야함
따라서 해당 요소 모두 is_deleted 처리해주기

### 이벤트 수정 기능 

-> 특정 이벤트의 지불 기한, 금액 이벤트명, 
    totalPaymentAmount, paymentDeadLine, name 수정 기능 구현

## 2. 로직

### 이벤트 삭제 기능
1. event를 isDeleted 처리하고 accountBook의 balance 값 변경

2. fee, eventBill, transactionHistory 모두 isDeleted 필드 없으면 추가하기

3. accountBook 조회해서 락걸고 event balance 만큼 accountBook 반영 
    fee 리스트, -> 총입금 금액 합쳐서 accountBook classifiedDeposit 수정 및 fee들 isDeleted true 처리
    eventBIll 리스트 -> 총출금 금액 합쳐서 accountBook classifiedWithdrawal 수정 eventBill들 isDeleted true 처리
    transactionHisotry 리스트 isDeleted true 처리하기


### 이벤트 수정 기능

1. 이벤트 이름, 걷는 금액, 마감 기한 수정할 수 있는 api 구현

## 3. 고려한 사항

이벤트 조회시 fee 리스트, eventBill 리스트, transcationHistory 리스트 N+1 문제 고려해서 조회해야함.

fee, eventBill, transactionHistory => JPQL로 update 쿼리를 작성하여 하나의 update 쿼리로 수정
@Modifying 
-> update, deleted, insert 쿼리를 실행할 때 사용한다. (벌크 연산용)
-> 1차 캐시 (영속성 컨텍스트를 무시하고 바로 query를 실행함

