### PR TITLE
[feat] issue-#59: 운영진 리스트 조회, 총무 권한 위임 구현

### DIFF
--- a/src/main/java/swm/backstage/movis/domain/club_user/controller/ClubUserController.java
+++ b/src/main/java/swm/backstage/movis/domain/club_user/controller/ClubUserController.java
@@ -7,16 +7,20 @@ import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import swm.backstage.movis.domain.auth.dto.AuthenticationPrincipalDetails;
+import swm.backstage.movis.domain.club_user.ClubUser;
 import swm.backstage.movis.domain.club_user.dto.ClubUserCreateReqDto;
 import swm.backstage.movis.domain.club_user.dto.ClubUserGetResDto;
+import swm.backstage.movis.domain.club_user.dto.ClubUserListGetResDto;
 import swm.backstage.movis.domain.club_user.service.ClubUserService;
+
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/clubUsers")
 public class ClubUserController {
 
-    private ClubUserService clubUserService;
+    private final ClubUserService clubUserService;
 
     @PreAuthorize("hasPermission(#clubUserCreateReqDto.clubId, 'clubId', {'ROLE_EXECUTIVE', 'ROLE_MANAGER'})")
     @PostMapping
@@ -24,9 +28,19 @@ public class ClubUserController {
         clubUserService.createClubUser(clubUserCreateReqDto);
     }
 
-//    @GetMapping()
-//    public ClubUserGetResDto getClubUser(@AuthenticationPrincipal AuthenticationPrincipalDetails principal,
-//                                         @RequestParam(name = "clubId") String clubId){
-//        return new ClubUserGetResDto(clubUserService.getClubUser(principal.getIdentifier(), clubId));
-//    }
+    @PreAuthorize("hasPermission(#clubId, 'clubId', {'ROLE_MANAGER'})")
+    @PatchMapping("/{toIdentifier}")
+    public void delegateRoleManagerToExecutive(@AuthenticationPrincipal AuthenticationPrincipalDetails principal,
+                                               @RequestParam("clubId") @Param("clubId") String clubId,
+                                               @PathVariable("toIdentifier") String toIdentifier) {
+        clubUserService.delegateRoleManagerToExecutive(principal.getIdentifier(), toIdentifier, clubId);
+    }
+
+    @PreAuthorize("hasPermission(#clubId, 'clubId', {'ROLE_MEMBER', 'ROLE_EXECUTIVE', 'ROLE_MANAGER'})")
+    @GetMapping()
+    public ClubUserListGetResDto getClubUserList(@RequestParam(name = "clubId") @Param("clubId") String clubId) {
+        return new ClubUserListGetResDto(clubUserService.getClubUserList(clubId)
+                .stream()
+                .map(clubUser -> new ClubUserGetResDto(clubUser.getUuid(), clubUser.getIdentifier(), clubUser.getRole())).toList());
+    }
 }

--- a/src/main/java/swm/backstage/movis/domain/club_user/dto/ClubUserGetResDto.java
+++ b/src/main/java/swm/backstage/movis/domain/club_user/dto/ClubUserGetResDto.java
@@ -2,15 +2,18 @@ package swm.backstage.movis.domain.club_user.dto;
 
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import swm.backstage.movis.domain.club_user.ClubUser;
 
 @Getter
 @NoArgsConstructor
 public class ClubUserGetResDto {
 
-    private String role;
+    String clubUserId;
+    String identifier;
+    String role;
 
-    public ClubUserGetResDto(ClubUser clubUser) {
-        this.role = clubUser.getRole();
+    public ClubUserGetResDto(String clubUserId, String identifier, String role) {
+        this.clubUserId = clubUserId;
+        this.identifier = identifier;
+        this.role = role;
     }
 }

--- a/src/main/java/swm/backstage/movis/domain/club_user/dto/ClubUserListGetResDto.java
+++ b/src/main/java/swm/backstage/movis/domain/club_user/dto/ClubUserListGetResDto.java
@@ -1,0 +1,18 @@
+package swm.backstage.movis.domain.club_user.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import swm.backstage.movis.domain.club_user.ClubUser;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+public class ClubUserListGetResDto {
+
+    private List<ClubUserGetResDto> clubUserGetResDtoList;
+
+    public ClubUserListGetResDto(List<ClubUserGetResDto> clubUserGetResDtoList) {
+        this.clubUserGetResDtoList = clubUserGetResDtoList;
+    }
+}

--- a/src/main/java/swm/backstage/movis/domain/club_user/repository/ClubUserRepository.java
+++ b/src/main/java/swm/backstage/movis/domain/club_user/repository/ClubUserRepository.java
@@ -3,9 +3,11 @@ package swm.backstage.movis.domain.club_user.repository;
 import org.springframework.data.jpa.repository.JpaRepository;
 import swm.backstage.movis.domain.club_user.ClubUser;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface ClubUserRepository extends JpaRepository<ClubUser, Long> {
 
     Optional<ClubUser> findByIdentifierAndClub_Uuid(String identifier, String clubId);
+    List<ClubUser> findAllByClub_Uuid(String clubId);
 }

--- a/src/main/java/swm/backstage/movis/domain/club_user/service/ClubUserService.java
+++ b/src/main/java/swm/backstage/movis/domain/club_user/service/ClubUserService.java
@@ -1,11 +1,13 @@
 package swm.backstage.movis.domain.club_user.service;
 
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import swm.backstage.movis.domain.club.Club;
 import swm.backstage.movis.domain.club.service.ClubService;
 import swm.backstage.movis.domain.club_user.ClubUser;
 import swm.backstage.movis.domain.club_user.dto.ClubUserCreateReqDto;
+import swm.backstage.movis.domain.club_user.dto.ClubUserListGetResDto;
 import swm.backstage.movis.domain.club_user.repository.ClubUserRepository;
 import swm.backstage.movis.domain.auth.RoleType;
 import swm.backstage.movis.domain.user.User;
@@ -13,6 +15,8 @@ import swm.backstage.movis.domain.user.service.UserService;
 import swm.backstage.movis.global.error.ErrorCode;
 import swm.backstage.movis.global.error.exception.BaseException;
 
+import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 @Service
@@ -23,6 +27,7 @@ public class ClubUserService {
     private final ClubService clubService;
     private final ClubUserRepository clubUserRepository;
 
+    @Transactional
     public void createClubUser(ClubUserCreateReqDto clubUserCreateReqDto) {
         Club club = clubService.findClubByUuId(clubUserCreateReqDto.getClubId());
         User user = userService.findByIdentifier(clubUserCreateReqDto.getIdentifier()).orElseThrow(()-> new BaseException("Element Not Found", ErrorCode.ELEMENT_NOT_FOUND));
@@ -30,7 +35,28 @@ public class ClubUserService {
         clubUserRepository.save(clubUser);
     }
 
+    @Transactional
+    public void delegateRoleManagerToExecutive(String fromIdentifier, String toIdentifier, String clubId) {
+        if (fromIdentifier.equals(toIdentifier)) {
+            throw new BaseException("자기 자신에게 권한을 위임할 수 없습니다. ", ErrorCode.INTERNAL_SERVER_ERROR);
+        }
+        ClubUser fromClubUser = clubUserRepository.findByIdentifierAndClub_Uuid(fromIdentifier, clubId)
+                .orElseThrow(() -> new BaseException("Element Not Found", ErrorCode.ELEMENT_NOT_FOUND));
+        ClubUser toClubUser = clubUserRepository.findByIdentifierAndClub_Uuid(toIdentifier, clubId)
+                .orElseThrow(() -> new BaseException("Element Not Found", ErrorCode.ELEMENT_NOT_FOUND));
+
+        fromClubUser.updateRole(RoleType.ROLE_EXECUTIVE.value());
+        toClubUser.updateRole(RoleType.ROLE_MANAGER.value());
+
+        clubUserRepository.save(fromClubUser);
+        clubUserRepository.save(toClubUser);
+    }
+
     public ClubUser getClubUser(String identifier, String clubId) {
         return clubUserRepository.findByIdentifierAndClub_Uuid(identifier, clubId).orElseThrow(() -> new BaseException("clubUser is not found", ErrorCode.ELEMENT_NOT_FOUND));
+    }
+
+    public List<ClubUser> getClubUserList(String clubId) {
+        return clubUserRepository.findAllByClub_Uuid(clubId);
     }
 }


### PR DESCRIPTION
## 이슈
- [총무 권한을 운영진에게 위임](https://github.com/swm-backstage/movis-backend/issues/59)

## 구현 기능
- 요청된 모임의 운영진 리스트 조회
- MANAGER가 EXECUTIVE에게 자신의 권한을 위임(서로의 권한이 바뀜)
자기 자신에게는 위임이 안되도록

## 작업 시간
1h