### PR TITLE
[fix] issue-#32: club 조회시 N+1 문제 해결

### DIFF
--- a/src/main/java/swm/backstage/movis/domain/club/controller/ClubController.java
+++ b/src/main/java/swm/backstage/movis/domain/club/controller/ClubController.java
@@ -5,12 +5,16 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.repository.query.Param;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 import swm.backstage.movis.domain.auth.dto.AuthenticationPrincipalDetails;
+import swm.backstage.movis.domain.club.Club;
 import swm.backstage.movis.domain.club.dto.*;
 import swm.backstage.movis.domain.club.service.ClubService;
 import swm.backstage.movis.domain.member.service.MemberService;
+
+import java.util.List;
 
 
 @RestController
@@ -34,7 +38,9 @@ public class ClubController {
     }
 
     @GetMapping()
+    @Transactional
     public ClubGetListResDto getClubList(@AuthenticationPrincipal AuthenticationPrincipalDetails principal){
+        List<Club> clubList = clubService.getClubList((principal.getIdentifier()));
         return new ClubGetListResDto(clubService.getClubList(principal.getIdentifier()));
     }
 

--- a/src/main/java/swm/backstage/movis/domain/club/service/ClubService.java
+++ b/src/main/java/swm/backstage/movis/domain/club/service/ClubService.java
@@ -3,6 +3,8 @@ package swm.backstage.movis.domain.club.service;
 
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 import swm.backstage.movis.domain.accout_book.AccountBook;
 import swm.backstage.movis.domain.auth.RoleType;
@@ -23,6 +25,7 @@ import java.util.stream.Collectors;
 @Service
 @RequiredArgsConstructor
 public class ClubService {
+    private static final Logger log = LoggerFactory.getLogger(ClubService.class);
     private final ClubRepository clubRepository;
     private final UserService userService;
 
@@ -67,11 +70,8 @@ public class ClubService {
     }
 
     public List<Club> getClubList(String identifier){
-        User user = userService.findByIdentifier(identifier).orElseThrow(()-> new BaseException("Element Not Found",ErrorCode.ELEMENT_NOT_FOUND));
-        List<ClubUser> clubUserList = user.getClubUserList();
-        return clubUserList.stream()
-                .map(ClubUser::getClub)
-                .collect(Collectors.toList());
+        User user = userService.findUserWithInfoByIdentifier(identifier);
+        return user.getClubUserList().stream().map(ClubUser::getClub).collect(Collectors.toList());
     }
 
     public String getClubUid(String accountNumber, String identifier) {

--- a/src/main/java/swm/backstage/movis/domain/user/repository/UserRepository.java
+++ b/src/main/java/swm/backstage/movis/domain/user/repository/UserRepository.java
@@ -1,6 +1,8 @@
 package swm.backstage.movis.domain.user.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import swm.backstage.movis.domain.user.User;
 
 import java.util.Optional;
@@ -10,4 +12,11 @@ public interface UserRepository extends JpaRepository<User, Long> {
     Boolean existsByIdentifier(String identifier);
 
     Optional<User> findByIdentifier(String identifier);
+
+    @Query("SELECT u FROM User u " +
+            "JOIN FETCH u.clubUserList cu " +
+            "JOIN FETCH cu.club c " +
+            "JOIN FETCH c.accountBook ab " +
+            "WHERE u.identifier = :identifier ")
+    Optional<User> findUserWithClubUserAndClubAndAccountBook(@Param("identifier") String identifier);
 }

--- a/src/main/java/swm/backstage/movis/domain/user/service/UserService.java
+++ b/src/main/java/swm/backstage/movis/domain/user/service/UserService.java
@@ -5,6 +5,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import swm.backstage.movis.domain.user.User;
 import swm.backstage.movis.domain.user.repository.UserRepository;
+import swm.backstage.movis.global.error.ErrorCode;
+import swm.backstage.movis.global.error.exception.BaseException;
 
 import java.util.Optional;
 
@@ -17,5 +19,10 @@ public class UserService {
     public Optional<User> findByIdentifier(String identifier) {
 
         return userRepository.findByIdentifier(identifier);
+    }
+
+    public User findUserWithInfoByIdentifier(String identifier) {
+        return userRepository.findUserWithClubUserAndClubAndAccountBook(identifier)
+                .orElseThrow(()-> new BaseException("유저를 찾을 수 없습니다.", ErrorCode.ELEMENT_NOT_FOUND));
     }
 }


### PR DESCRIPTION
## 구현한 기능

Club 리스트 조회 api 이용시 club의 accout book 개수만큼 쿼리가 날라가는 JPA N+1 문제를 해결하였다.

총 10개의 모임 리스트를 조회하는 경우 날아가는 쿼리  : 13개 -> 2개

![image](https://github.com/user-attachments/assets/5e340244-414f-4399-8d74-d4b803d35f3c)

이런 연관관계 매핑에서 user의 uuid를 바탕으로 club의 정보 + accout book의정보 + member의 수를 얻어야하는 로직이 존재했는데 JPA의 지연로딩을 사용해서 조회하고 있었다.

따라서, JPA의 fetch join을 사용하여 쿼리 개수
3+N 개  -->  2개
로 변경하였다.

members까지 같이 조회하지 못한 것은 여러개의 OneToMany를 한번에 fetch join 할 수 없어서 마지막에 members만 batch size 옵션을 통해 조회하였다. 

## 쿼리 변화


### 변경 전
![image](https://github.com/user-attachments/assets/f793f7b7-0f11-4213-b666-f34c2c15f4fe)
![image](https://github.com/user-attachments/assets/13e09bb4-8844-4257-aeb0-75384e812e58)
![image](https://github.com/user-attachments/assets/9b804207-5690-4d53-9ad6-7a0d3210e72e)
![image](https://github.com/user-attachments/assets/06cead43-513e-4302-b036-c382babc3063)


### 변경 후

```sql
Hibernate: 
    select
        u1_0.id,
        cul1_0.user_id,
        cul1_0.id,
        c1_0.id,
        ab1_0.id,
        ab1_0.balance,
        ab1_0.classified_deposit,
        ab1_0.classified_withdrawal,
        ab1_0.un_classified_deposit,
        ab1_0.un_classified_withdrawal,
        c1_0.account_number,
        c1_0.bank_code,
        c1_0.created_at,
        c1_0.deleted_at,
        c1_0.description,
        c1_0.entry_code,
        c1_0.invite_code,
        c1_0.is_deleted,
        c1_0.name,
        c1_0.updated_at,
        c1_0.uuid,
        cul1_0.club_uuid,
        cul1_0.identifier,
        cul1_0.role,
        cul1_0.uuid,
        u1_0.created_at,
        u1_0.deleted_at,
        u1_0.identifier,
        u1_0.is_deleted,
        u1_0.name,
        u1_0.password,
        u1_0.phone_no,
        u1_0.updated_at,
        u1_0.uuid 
    from
        user u1_0 
    join
        club_user cul1_0 
            on u1_0.id=cul1_0.user_id 
    join
        club c1_0 
            on c1_0.id=cul1_0.club_id 
    join
        account_book ab1_0 
            on c1_0.id=ab1_0.club_id 
    where
        u1_0.identifier=?
```
![image](https://github.com/user-attachments/assets/d254bad8-82c8-4400-b5ff-ebc85feca54d)



