### PR TITLE
[feat] issue-#65: 멤버 인증 시 JWT 토큰 발급

### DIFF
--- a/src/main/java/swm/backstage/movis/domain/auth/dto/AuthTokenDto.java
+++ b/src/main/java/swm/backstage/movis/domain/auth/dto/AuthTokenDto.java
@@ -1,0 +1,18 @@
+package swm.backstage.movis.domain.auth.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import swm.backstage.movis.domain.auth.AuthToken;
+
+@Getter
+@NoArgsConstructor
+public class AuthTokenDto {
+
+    private String accessToken;
+    private String refreshToken;
+
+    public AuthTokenDto(AuthToken authToken) {
+        this.accessToken = authToken.getAccessToken();
+        this.refreshToken = authToken.getRefreshToken();
+    }
+}

--- a/src/main/java/swm/backstage/movis/domain/auth/service/AuthService.java
+++ b/src/main/java/swm/backstage/movis/domain/auth/service/AuthService.java
@@ -13,6 +13,7 @@ import org.springframework.validation.annotation.Validated;
 import swm.backstage.movis.domain.auth.AuthToken;
 import swm.backstage.movis.domain.auth.PlatformType;
 import swm.backstage.movis.domain.auth.RsaPrivateKey;
+import swm.backstage.movis.domain.auth.dto.AuthTokenDto;
 import swm.backstage.movis.domain.auth.dto.RSAKeyPairDto;
 import swm.backstage.movis.domain.auth.dto.request.*;
 import swm.backstage.movis.domain.auth.dto.response.ConfirmIdentifierResDto;
@@ -117,25 +118,11 @@ public class AuthService {
             throw new BaseException("비밀번호가 일치하지 않습니다.", ErrorCode.INVALID_PASSWORD);
         }
 
-        String accessToken = jwtUtil.createToken(
-                jwtUtil.getACCESS_TOKEN_NAME(),
-                PlatformType.APP.value(),
-                identifier,
-                jwtUtil.getACCESS_TOKEN_EXPIRED_TIME()
-        );
-        String refreshToken = jwtUtil.createToken(
-                jwtUtil.getREFRESH_TOKEN_NAME(),
-                PlatformType.APP.value(),
-                identifier,
-                jwtUtil.getREFRESH_TOKEN_EXPIRED_TIME()
-        );
-
-        authTokenService.deleteAllByIdentifier(identifier);
-        authTokenService.addAuthToken(identifier, accessToken, refreshToken);
+        AuthTokenDto authTokenDto = authTokenService.issueAuthToken(identifier, PlatformType.APP.value());
 
         return new UserLoginResDto(
-                accessToken,
-                refreshToken
+                authTokenDto.getAccessToken(),
+                authTokenDto.getAccessToken()
         );
     }
 
@@ -209,23 +196,12 @@ public class AuthService {
             throw new BaseException("유효하지 않은 토큰 입니다. 다시 로그인 해주세요. ", ErrorCode.INVALID_TOKEN);
         }
 
-        String newAccessToken = jwtUtil.createToken(
-                jwtUtil.getACCESS_TOKEN_NAME(),
-                PlatformType.APP.value(),
-                identifier,
-                jwtUtil.getACCESS_TOKEN_EXPIRED_TIME()
-        );
-        String newRefreshToken = jwtUtil.createToken(
-                jwtUtil.getREFRESH_TOKEN_NAME(),
-                PlatformType.APP.value(),
-                identifier,
-                jwtUtil.getREFRESH_TOKEN_EXPIRED_TIME()
-        );
+        AuthTokenDto authTokenDto = authTokenService.issueAuthToken(identifier, PlatformType.APP.value());
 
-        authTokenService.deleteAllByIdentifier(identifier);
-        authTokenService.addAuthToken(identifier, newAccessToken, newRefreshToken);
-
-        return new JwtCreateResDto(newAccessToken, newRefreshToken);
+        return new JwtCreateResDto(
+                authTokenDto.getAccessToken(),
+                authTokenDto.getAccessToken()
+        );
     }
 
     public PublicKeyGetResDto getPublicKey() {

--- a/src/main/java/swm/backstage/movis/domain/auth/service/AuthTokenService.java
+++ b/src/main/java/swm/backstage/movis/domain/auth/service/AuthTokenService.java
@@ -4,7 +4,10 @@ import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import swm.backstage.movis.domain.auth.AuthToken;
+import swm.backstage.movis.domain.auth.PlatformType;
+import swm.backstage.movis.domain.auth.dto.AuthTokenDto;
 import swm.backstage.movis.domain.auth.repository.AuthTokenRepository;
+import swm.backstage.movis.domain.auth.utils.JwtUtil;
 
 import java.util.Optional;
 
@@ -17,11 +20,32 @@ import java.util.Optional;
 public class AuthTokenService {
 
     private final AuthTokenRepository authTokenRepository;
+    private final JwtUtil jwtUtil;
 
     @Transactional
-    public void addAuthToken(String identifier, String accessToken, String refreshToken){
+    public AuthTokenDto issueAuthToken(String identifier, String platformType) {
 
-        authTokenRepository.save(new AuthToken(
+        String accessToken = jwtUtil.createToken(
+                jwtUtil.getACCESS_TOKEN_NAME(),
+                platformType,
+                identifier,
+                jwtUtil.getACCESS_TOKEN_EXPIRED_TIME()
+        );
+        String refreshToken = jwtUtil.createToken(
+                jwtUtil.getREFRESH_TOKEN_NAME(),
+                platformType,
+                identifier,
+                jwtUtil.getREFRESH_TOKEN_EXPIRED_TIME()
+        );
+
+        this.deleteAllByIdentifier(identifier);
+        return new AuthTokenDto(this.addAuthToken(identifier, accessToken, refreshToken));
+    }
+
+    @Transactional
+    public AuthToken addAuthToken(String identifier, String accessToken, String refreshToken){
+
+        return authTokenRepository.save(new AuthToken(
                 identifier,
                 accessToken,
                 refreshToken

--- a/src/main/java/swm/backstage/movis/domain/club/controller/ClubController.java
+++ b/src/main/java/swm/backstage/movis/domain/club/controller/ClubController.java
@@ -8,7 +8,11 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
+import swm.backstage.movis.domain.auth.PlatformType;
+import swm.backstage.movis.domain.auth.dto.AuthTokenDto;
 import swm.backstage.movis.domain.auth.dto.AuthenticationPrincipalDetails;
+import swm.backstage.movis.domain.auth.dto.response.JwtCreateResDto;
+import swm.backstage.movis.domain.auth.service.AuthTokenService;
 import swm.backstage.movis.domain.club.Club;
 import swm.backstage.movis.domain.club.dto.*;
 import swm.backstage.movis.domain.club.service.ClubService;
@@ -24,6 +28,7 @@ public class ClubController {
 
     private final ClubService clubService;
     private final MemberService memberService;
+    private final AuthTokenService authTokenService;
 
     @PostMapping()
     public ClubGetResDto createClub(@AuthenticationPrincipal AuthenticationPrincipalDetails principal,
@@ -66,10 +71,17 @@ public class ClubController {
     // 해당 멤버가 있는지 확인 후, clubId 반환
     // TODO : 멤버에게 JWT 토큰 전달
     @PostMapping("/entryCode/verify")
-    public String verifyMember(@RequestBody ClubEntryReqDto clubEntryReqDto){
+    public MemberVerifyResDto verifyMember(@RequestBody ClubEntryReqDto clubEntryReqDto){
         String clubId = clubService.getClubUuidByEntryCode(clubEntryReqDto.getEntryCode());
         memberService.isMemberExist(clubId, clubEntryReqDto.getName(), clubEntryReqDto.getPhoneNumber());
-        return clubId;
+
+        AuthTokenDto authTokenDto = authTokenService.issueAuthToken(clubEntryReqDto.getName(), PlatformType.APP.value());
+
+        return new MemberVerifyResDto(
+                clubId,
+                authTokenDto.getAccessToken(),
+                authTokenDto.getAccessToken()
+        );
     }
 
     /**

--- a/src/main/java/swm/backstage/movis/domain/club/dto/MemberVerifyResDto.java
+++ b/src/main/java/swm/backstage/movis/domain/club/dto/MemberVerifyResDto.java
@@ -1,0 +1,19 @@
+package swm.backstage.movis.domain.club.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class MemberVerifyResDto {
+
+    private String clubId;
+    private String accessToken;
+    private String refreshToken;
+
+    public MemberVerifyResDto(String clubId, String accessToken, String refreshToken) {
+        this.clubId = clubId;
+        this.accessToken = accessToken;
+        this.refreshToken = refreshToken;
+    }
+}


### PR DESCRIPTION
## 이슈
- [모임 회원 인증시 토큽 발급](https://github.com/swm-backstage/movis-backend/issues/65)

## 구현 기능
- ClubController의 verifyMember및 이하 서비스 로직 수정
- authTokenService에서 accessToken과 refreshToken을 일괄 발급하여 저장하는 issueAuthToken메서드 구현

## 작업 시간
0.3h