### PR TITLE
[featrue] issue-#80: id, uuid -> ulid로 변경하기

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -59,6 +59,9 @@ dependencies {
 	//aws
 	implementation platform('com.amazonaws:aws-java-sdk-bom:1.12.529')
 	implementation 'com.amazonaws:aws-java-sdk-s3'
+
+	//ulid
+	implementation 'com.github.f4b6a3:ulid-creator:5.2.3'
 }
 
 tasks.named('test') {

--- a/src/main/java/swm/backstage/movis/domain/accout_book/AccountBook.java
+++ b/src/main/java/swm/backstage/movis/domain/accout_book/AccountBook.java
@@ -32,7 +32,7 @@ public class AccountBook {
         this.unClassifiedWithdrawal = 0L;
     }
 
-    @OneToOne(fetch = FetchType.LAZY)
+    @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.PERSIST)
     @JoinColumn(name = "club_id")
     private Club club;
 

--- a/src/main/java/swm/backstage/movis/domain/accout_book/repository/AccountBookRepository.java
+++ b/src/main/java/swm/backstage/movis/domain/accout_book/repository/AccountBookRepository.java
@@ -14,7 +14,7 @@ public interface AccountBookRepository extends JpaRepository<AccountBook, Long> 
 
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @QueryHints({@QueryHint(name = "javax.persistence.query.timeout", value = "10000")})
-    @Query("SELECT a FROM AccountBook a WHERE a.club.uuid = :clubId ")
+    @Query("SELECT a FROM AccountBook a WHERE a.club.ulid = :clubId ")
     Optional<AccountBook> findByClubIdWithLock(String clubId);
 
 }

--- a/src/main/java/swm/backstage/movis/domain/accout_book/service/AccountBookService.java
+++ b/src/main/java/swm/backstage/movis/domain/accout_book/service/AccountBookService.java
@@ -22,5 +22,10 @@ public class AccountBookService {
                 .orElseThrow(()->new BaseException("account book is not found", ErrorCode.ELEMENT_NOT_FOUND));
     }
 
+    @Transactional
+    public AccountBook createAccountBook(AccountBook accountBook) {
+        return accountBookRepository.save(accountBook);
+    }
+
 
 }

--- a/src/main/java/swm/backstage/movis/domain/auth/filter/CustomPermissionEvaluator.java
+++ b/src/main/java/swm/backstage/movis/domain/auth/filter/CustomPermissionEvaluator.java
@@ -49,11 +49,11 @@ public class CustomPermissionEvaluator implements PermissionEvaluator {
         if(targetType.equals("clubId")){
             return targetId;
         } else if(targetType.equals("eventId")){
-            return eventService.getEventByUuid(targetId).getClub().getUuid();
+            return eventService.getEventByUuid(targetId).getClub().getUlid();
         } else if(targetType.equals("eventBillId")){
-            return eventBillService.getEventBillByUuid(targetId).getClub().getUuid();
+            return eventBillService.getEventBillByUuid(targetId).getClub().getUlid();
         } else if(targetType.equals("feeId")){
-            return feeService.getFeeByUuId(targetId).getClub().getUuid();
+            return feeService.getFeeByUuId(targetId).getClub().getUlid();
         }
         return null;
     }

--- a/src/main/java/swm/backstage/movis/domain/club/Club.java
+++ b/src/main/java/swm/backstage/movis/domain/club/Club.java
@@ -1,5 +1,6 @@
 package swm.backstage.movis.domain.club;
 
+import com.github.f4b6a3.ulid.UlidCreator;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -26,12 +27,8 @@ import java.util.List;
 public class Club extends DateTimeField {
 
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "id")
-    private Long id;
-
-    @Column(unique = true ,name = "uuid", length = 36)
-    private String uuid;
+    @Column(unique = true , length = 26)
+    private String ulid;
 
     @Column(name="name", nullable = false, length = 30)
     private String name;
@@ -84,19 +81,21 @@ public class Club extends DateTimeField {
     private String inviteCode;
 
 
-    public Club(ClubCreateReqDto clubCreateReqDto, String uuid, AccountBook accountBook) {
-        this.uuid = uuid;
+    public Club(ClubCreateReqDto clubCreateReqDto, AccountBook accountBook, String entryCode, String inviteCode) {
+        this.ulid = UlidCreator.getUlid().toString();
         this.description = clubCreateReqDto.getDescription();
         this.name = clubCreateReqDto.getName();
         this.accountNumber = clubCreateReqDto.getAccountNumber();
         this.bankCode = clubCreateReqDto.getBankCode();
         this.isDeleted = Boolean.FALSE;
-        this.accountBook = accountBook;
         this.thumbnail = clubCreateReqDto.getThumbnail();
-        accountBook.setClub(this);
+        this.accountBook = accountBook;
+        this.entryCode = entryCode;
+        this.inviteCode = inviteCode;
     }
 
     public void addClubUser(ClubUser clubUser) {
         clubUserList.add(clubUser);
     }
+
 }

--- a/src/main/java/swm/backstage/movis/domain/club/controller/ClubController.java
+++ b/src/main/java/swm/backstage/movis/domain/club/controller/ClubController.java
@@ -32,7 +32,8 @@ public class ClubController {
     @PostMapping()
     public ClubGetResDto createClub(@AuthenticationPrincipal AuthenticationPrincipalDetails principal,
                                     @RequestBody @Validated ClubCreateReqDto clubCreateReqDto) {
-        return new ClubGetResDto(clubService.createClub(clubCreateReqDto, principal.getIdentifier()));
+        ClubGetResDto response = new ClubGetResDto(clubService.createClub(clubCreateReqDto, principal.getIdentifier()));
+        return response;
     }
 
     @PreAuthorize("hasPermission(#clubId, 'clubId', {'ROLE_MEMBER', 'ROLE_EXECUTIVE', 'ROLE_MANAGER'})")

--- a/src/main/java/swm/backstage/movis/domain/club/dto/ClubGetElementResDto.java
+++ b/src/main/java/swm/backstage/movis/domain/club/dto/ClubGetElementResDto.java
@@ -21,7 +21,7 @@ public class ClubGetElementResDto {
     private int memberCnt;
 
     public ClubGetElementResDto(Club club) {
-        this.clubId = club.getUuid();
+        this.clubId = club.getUlid();
         this.name = club.getName();
         this.description = club.getDescription();
         this.accountNumber = club.getAccountNumber();

--- a/src/main/java/swm/backstage/movis/domain/club/dto/ClubGetResDto.java
+++ b/src/main/java/swm/backstage/movis/domain/club/dto/ClubGetResDto.java
@@ -3,12 +3,14 @@ package swm.backstage.movis.domain.club.dto;
 
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.ToString;
 import swm.backstage.movis.domain.club.Club;
 
 import java.time.LocalDateTime;
 
 @Getter
 @NoArgsConstructor
+@ToString
 public class ClubGetResDto {
     private String clubId;
     private String name;
@@ -20,7 +22,7 @@ public class ClubGetResDto {
     private String bankCode;
 
     public ClubGetResDto(Club club) {
-        this.clubId = club.getUuid();
+        this.clubId = club.getUlid();
         this.name = club.getName();
         this.description = club.getDescription();
         this.accountNumber = club.getAccountNumber();

--- a/src/main/java/swm/backstage/movis/domain/club/repository/ClubRepository.java
+++ b/src/main/java/swm/backstage/movis/domain/club/repository/ClubRepository.java
@@ -6,8 +6,8 @@ import swm.backstage.movis.domain.club.Club;
 
 import java.util.Optional;
 
-public interface ClubRepository extends JpaRepository<Club, Long> {
-    Optional<Club> findByUuidAndIsDeleted(String id, Boolean deleted);
+public interface ClubRepository extends JpaRepository<Club, String> {
+    Optional<Club> findByUlidAndIsDeleted(String id, Boolean deleted);
     Optional<Club> findByEntryCode(String entryCode);
     Optional<Club> findByInviteCode(String inviteCode);
 }

--- a/src/main/java/swm/backstage/movis/domain/club_user/ClubUser.java
+++ b/src/main/java/swm/backstage/movis/domain/club_user/ClubUser.java
@@ -49,7 +49,7 @@ public class ClubUser {
         this.uuid = uuid;
         this.roleType = roleType;
         this.identifier = user.getIdentifier();
-        this.clubUuid = club.getUuid();
+        this.clubUuid = club.getUlid();
         this.user = user;
         this.club = club;
         club.addClubUser(this);

--- a/src/main/java/swm/backstage/movis/domain/club_user/repository/ClubUserRepository.java
+++ b/src/main/java/swm/backstage/movis/domain/club_user/repository/ClubUserRepository.java
@@ -8,6 +8,6 @@ import java.util.Optional;
 
 public interface ClubUserRepository extends JpaRepository<ClubUser, Long> {
 
-    Optional<ClubUser> findByIdentifierAndClub_Uuid(String identifier, String clubId);
-    List<ClubUser> findAllByClub_Uuid(String clubId);
+    Optional<ClubUser> findByIdentifierAndClub_Ulid(String identifier, String clubId);
+    List<ClubUser> findAllByClub_Ulid(String clubId);
 }

--- a/src/main/java/swm/backstage/movis/domain/club_user/service/ClubUserService.java
+++ b/src/main/java/swm/backstage/movis/domain/club_user/service/ClubUserService.java
@@ -38,9 +38,9 @@ public class ClubUserService {
         if (fromIdentifier.equals(toIdentifier)) {
             throw new BaseException("자기 자신에게 권한을 위임할 수 없습니다. ", ErrorCode.INTERNAL_SERVER_ERROR);
         }
-        ClubUser fromClubUser = clubUserRepository.findByIdentifierAndClub_Uuid(fromIdentifier, clubId)
+        ClubUser fromClubUser = clubUserRepository.findByIdentifierAndClub_Ulid(fromIdentifier, clubId)
                 .orElseThrow(() -> new BaseException("Element Not Found", ErrorCode.ELEMENT_NOT_FOUND));
-        ClubUser toClubUser = clubUserRepository.findByIdentifierAndClub_Uuid(toIdentifier, clubId)
+        ClubUser toClubUser = clubUserRepository.findByIdentifierAndClub_Ulid(toIdentifier, clubId)
                 .orElseThrow(() -> new BaseException("Element Not Found", ErrorCode.ELEMENT_NOT_FOUND));
 
         fromClubUser.updateRole(RoleType.ROLE_EXECUTIVE);
@@ -51,10 +51,10 @@ public class ClubUserService {
     }
 
     public ClubUser getClubUser(String identifier, String clubId) {
-        return clubUserRepository.findByIdentifierAndClub_Uuid(identifier, clubId).orElseThrow(() -> new BaseException("clubUser is not found", ErrorCode.ELEMENT_NOT_FOUND));
+        return clubUserRepository.findByIdentifierAndClub_Ulid(identifier, clubId).orElseThrow(() -> new BaseException("clubUser is not found", ErrorCode.ELEMENT_NOT_FOUND));
     }
 
     public List<ClubUser> getClubUserList(String clubId) {
-        return clubUserRepository.findAllByClub_Uuid(clubId);
+        return clubUserRepository.findAllByClub_Ulid(clubId);
     }
 }

--- a/src/main/java/swm/backstage/movis/domain/event/Event.java
+++ b/src/main/java/swm/backstage/movis/domain/event/Event.java
@@ -1,6 +1,7 @@
 package swm.backstage.movis.domain.event;
 
 
+import com.github.f4b6a3.ulid.UlidCreator;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -20,18 +21,14 @@ import java.util.List;
 @Entity
 @Table(name = "event", indexes = {
         @Index(name = "idx_club_id", columnList = "club_id"),
-        @Index(name = "idx_club_id_event_id", columnList = "club_id, id")})
+        @Index(name = "idx_club_id_event_id", columnList = "club_id, ulid")})
 @NoArgsConstructor
 @Getter
 public class Event {
 
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "id")
-    private Long id;
-
-    @Column(unique = true, nullable = false, length = 36)
-    private String uuid;
+    @Column(unique = true, nullable = false, length = 26)
+    private String ulid;
 
     @Column(name = "name", nullable = false, length = 50)
     private String name;
@@ -68,8 +65,8 @@ public class Event {
     @Column(name="is_deleted")
     private Boolean isDeleted;
 
-    public Event(String uuid, EventCreateReqDto eventCreateReqDto, Club club, AccountBook accountBook) {
-        this.uuid = uuid;
+    public Event( EventCreateReqDto eventCreateReqDto, Club club, AccountBook accountBook) {
+        this.ulid = UlidCreator.getUlid().toString();
         this.name = eventCreateReqDto.getEventName();
         this.club =club;
         this.accountBook = accountBook;

--- a/src/main/java/swm/backstage/movis/domain/event/dto/EventGetDto.java
+++ b/src/main/java/swm/backstage/movis/domain/event/dto/EventGetDto.java
@@ -23,7 +23,7 @@ public class EventGetDto {
     private LocalDate paymentDeadline;
 
     public EventGetDto(Event event) {
-        this.eventId = event.getUuid();
+        this.eventId = event.getUlid();
         this.name = event.getName();
         this.balance = event.getBalance();
         this.totalPaymentAmount = event.getTotalPaymentAmount();

--- a/src/main/java/swm/backstage/movis/domain/event/dto/EventGetFundingElementResDto.java
+++ b/src/main/java/swm/backstage/movis/domain/event/dto/EventGetFundingElementResDto.java
@@ -19,7 +19,7 @@ public class EventGetFundingElementResDto {
     private LocalDate paymentDeadline;
 
     public EventGetFundingElementResDto(Event event) {
-        this.eventId = event.getUuid();
+        this.eventId = event.getUlid();
         this.name = event.getName();
         this.totalPaymentAmount = event.getTotalPaymentAmount();
         this.paymentDeadline = event.getPaymentDeadline();

--- a/src/main/java/swm/backstage/movis/domain/event/dto/EventGetPagingListElementDto.java
+++ b/src/main/java/swm/backstage/movis/domain/event/dto/EventGetPagingListElementDto.java
@@ -15,7 +15,7 @@ public class EventGetPagingListElementDto {
     private Long balance;
 
     public EventGetPagingListElementDto(Event event) {
-        this.eventId = event.getUuid();
+        this.eventId = event.getUlid();
         this.name = event.getName();
         this.balance = event.getBalance();
     }

--- a/src/main/java/swm/backstage/movis/domain/event/repository/EventRepository.java
+++ b/src/main/java/swm/backstage/movis/domain/event/repository/EventRepository.java
@@ -10,27 +10,27 @@ import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 
-public interface EventRepository extends JpaRepository<Event, Long> {
-    Optional<Event> findByUuid(String uuid);
+public interface EventRepository extends JpaRepository<Event, String> {
+    Optional<Event> findByUlid(String ulid);
 
-    @Query("SELECT e from Event e where e.club.uuid= :clubId and e.totalPaymentAmount= :amount")
+    @Query("SELECT e from Event e where e.club.ulid= :clubId and e.totalPaymentAmount= :amount")
     List<Event> findByClubIdAndTotalPaymentAmount(String clubId, Long amount);
 
     // 1 회차용
     @Query("SELECT e FROM Event e " +
-            "WHERE e.club.id = :clubId " +
+            "WHERE e.club.ulid = :clubId " +
             "ORDER BY e.id DESC " +
             "LIMIT :size")
-    List<Event> getFirstPage(@Param("clubId") Long clubId,
+    List<Event> getFirstPage(@Param("clubId") String clubId,
                            @Param("size") int size);
 
     // n 회차용
     @Query("SELECT e FROM Event e " +
-            "WHERE e.club.id = :clubId AND e.id < :lastId  " +
-            "ORDER BY e.id DESC " +
+            "WHERE e.club.ulid = :clubId AND e.ulid < :lastId  " +
+            "ORDER BY e.ulid DESC " +
             "LIMIT :size")
-    List<Event> getNextPageByEventIdAndLastId(@Param("clubId") Long clubId,
-                                            @Param("lastId") Long lastId,
+    List<Event> getNextPageByEventIdAndLastId(@Param("clubId") String clubId,
+                                            @Param("lastId") String lastId,
                                             @Param("size") int size);
 
     @Query("SELECT e FROM Event e " +

--- a/src/main/java/swm/backstage/movis/domain/event/service/EventManager.java
+++ b/src/main/java/swm/backstage/movis/domain/event/service/EventManager.java
@@ -18,7 +18,7 @@ public class EventManager {
         Event event = eventService.createEvent(eventCreateReqDto);
 
         // 2. 생성된 event로 eventMemberList가 있다면 eventMemberList도 등록한다.
-        eventMemberService.addEventMembers(new EventMemberListReqDto(event.getUuid(),eventCreateReqDto.getEventMemberIdList()));
+        eventMemberService.addEventMembers(new EventMemberListReqDto(event.getUlid(),eventCreateReqDto.getEventMemberIdList()));
 
     }
 }

--- a/src/main/java/swm/backstage/movis/domain/event/service/EventService.java
+++ b/src/main/java/swm/backstage/movis/domain/event/service/EventService.java
@@ -42,14 +42,14 @@ public class EventService {
     @Transactional
     public Event createEvent(EventCreateReqDto eventCreateReqDto) {
         Club club = clubService.getClubByUuId(eventCreateReqDto.getClubId());
-        return eventRepository.save(new Event(UUID.randomUUID().toString(), eventCreateReqDto,club,club.getAccountBook()));
+        return eventRepository.save(new Event( eventCreateReqDto,club,club.getAccountBook()));
     }
 
     /**
      * null 허용 X
      * */
     public Event getEventByUuid(String eventId) {
-        return eventRepository.findByUuid(eventId).orElseThrow(()->new BaseException("eventId is not found", ErrorCode.ELEMENT_NOT_FOUND));
+        return eventRepository.findByUlid(eventId).orElseThrow(()->new BaseException("eventId is not found", ErrorCode.ELEMENT_NOT_FOUND));
     }
 
     /**
@@ -66,8 +66,8 @@ public class EventService {
     /**
      * null 허용 O
      * */
-    public Event findEventByUuid(String eventUuid) {
-        return eventRepository.findByUuid(eventUuid).orElse(null);
+    public Event findEventByUlid(String eventUlid) {
+        return eventRepository.findByUlid(eventUlid).orElse(null);
     }
 
 
@@ -78,11 +78,11 @@ public class EventService {
         Club club = clubService.getClubByUuId(clubId);
         List<Event> eventList;
         if(lastId.equals("first")){
-            eventList = eventRepository.getFirstPage(club.getId(),size+1);
+            eventList = eventRepository.getFirstPage(club.getUlid(),size+1);
         }
         else{
             Event event = getEventByUuid(lastId);
-            eventList = eventRepository.getNextPageByEventIdAndLastId(club.getId(),event.getId(),size+1);
+            eventList = eventRepository.getNextPageByEventIdAndLastId(club.getUlid(),event.getUlid(),size+1);
         }
         Boolean isLast = eventList.size() < size + 1;
         if(!isLast){
@@ -123,14 +123,14 @@ public class EventService {
 
         //2. deposit 관련 수정
         long deposit = 0;
-        feeManager.updateIsDeleted(event.getId());
+        feeManager.updateIsDeleted(event.getUlid());
         for(Fee fee : event.getFees()){
            deposit = deposit + fee.getPaidAmount();
         }
         accountBook.updateClassifiedDeposit(-deposit);
 
         //3. eventBill 수정
-        eventBillManager.updateIsDeleted(event.getId());
+        eventBillManager.updateIsDeleted(event.getUlid());
         long withdraw = 0L;
         for(EventBill eventBill : event.getEventBills()){
             withdraw = withdraw + eventBill.getAmount();
@@ -138,7 +138,7 @@ public class EventService {
         accountBook.updateClassifiedWithdrawal(-withdraw);
 
         //4. transactionHistory 수정
-        transactionHistoryManager.updateIsDeleted(event.getId());
+        transactionHistoryManager.updateIsDeleted(event.getUlid());
     }
 
 

--- a/src/main/java/swm/backstage/movis/domain/event_bill/EventBill.java
+++ b/src/main/java/swm/backstage/movis/domain/event_bill/EventBill.java
@@ -1,6 +1,7 @@
 package swm.backstage.movis.domain.event_bill;
 
 
+import com.github.f4b6a3.ulid.UlidCreator;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -16,18 +17,15 @@ import java.time.LocalDateTime;
 @Entity
 @Table(name = "event_bill", indexes = {
         @Index(name = "idx_event_id", columnList = "event_id"),
-        @Index(name = "idx_event_id_eb_id", columnList = "event_id, id")
+        @Index(name = "idx_event_id_eb_id", columnList = "event_id, ulid")
 })
 @NoArgsConstructor
 @Getter
 public class EventBill extends DateTimeField {
 
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
-
     @Column(name = "uuid",unique = true,nullable = false)
-    private String uuid;
+    private String ulid;
 
     @Column(name = "amount")
     private Long amount;
@@ -55,8 +53,8 @@ public class EventBill extends DateTimeField {
     @JoinColumn(name = "club_id")
     private Club club;
 
-    public EventBill(String uuid, EventBillCreateReqDto eventBillCreateReqDto, Club club) {
-        this.uuid = uuid;
+    public EventBill(EventBillCreateReqDto eventBillCreateReqDto, Club club) {
+        this.ulid = UlidCreator.getUlid().toString();
         this.payName = eventBillCreateReqDto.getPayName();
         this.amount = eventBillCreateReqDto.getAmount();
         this.club = club;
@@ -64,8 +62,8 @@ public class EventBill extends DateTimeField {
         this.isDeleted = false;
     }
 
-    public EventBill(String string, EventBillInputReqDto dto, Club club, Event event) {
-        this.uuid = string;
+    public EventBill(EventBillInputReqDto dto, Club club, Event event) {
+        this.ulid = UlidCreator.getUlid().toString();
         this.payName = dto.getName();
         this.amount = dto.getPaidAmount();
         this.club = club;

--- a/src/main/java/swm/backstage/movis/domain/event_bill/dto/EventBillGetElementResDto.java
+++ b/src/main/java/swm/backstage/movis/domain/event_bill/dto/EventBillGetElementResDto.java
@@ -13,7 +13,7 @@ public class EventBillGetElementResDto {
     private Long amount;
 
     public EventBillGetElementResDto(EventBill eventBill) {
-        this.eventId = eventBill.getUuid();
+        this.eventId = eventBill.getUlid();
         this.name = eventBill.getPayName();
         this.amount = eventBill.getAmount();
     }

--- a/src/main/java/swm/backstage/movis/domain/event_bill/repository/EventBillRepository.java
+++ b/src/main/java/swm/backstage/movis/domain/event_bill/repository/EventBillRepository.java
@@ -10,34 +10,34 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
-public interface EventBillRepository extends JpaRepository<EventBill, Long> {
-    Optional<EventBill> findByUuid(String uuid);
+public interface EventBillRepository extends JpaRepository<EventBill, String> {
+    Optional<EventBill> findByUlid(String ulid);
 
     // 1 회차용
     @Query("SELECT eb FROM EventBill eb " +
-            "WHERE eb.event.id = :eventId " +
+            "WHERE eb.event.ulid = :eventId " +
             "AND eb.paidAt <= :lastPaidAt " +
-            "ORDER BY eb.paidAt DESC , eb.id ASC " +
+            "ORDER BY eb.paidAt DESC , eb.ulid ASC " +
             "LIMIT :size")
-    List<EventBill> getFirstPage(@Param("eventId") Long eventId,
+    List<EventBill> getFirstPage(@Param("eventId") String eventId,
                                  @Param("lastPaidAt") LocalDateTime lastPaidAt,
                                  @Param("size") int size);
 
     // n 회차용
     @Query("SELECT eb FROM EventBill eb " +
-            "WHERE eb.event.id = :eventId AND eb.id < :lastId  " +
-            "AND ((eb.paidAt = :lastPaidAt AND eb.id > :lastId) OR (eb.paidAt < :lastPaidAt)) " +
-            "ORDER BY eb.paidAt DESC , eb.id ASC " +
+            "WHERE eb.event.ulid = :eventId AND eb.ulid < :lastId  " +
+            "AND ((eb.paidAt = :lastPaidAt AND eb.ulid > :lastId) OR (eb.paidAt < :lastPaidAt)) " +
+            "ORDER BY eb.paidAt DESC , eb.ulid ASC " +
             "LIMIT :size")
-    List<EventBill> getNextPage(@Param("eventId") Long eventId,
+    List<EventBill> getNextPage(@Param("eventId") String eventId,
                                 @Param("lastPaidAt") LocalDateTime lastPaidAt,
-                                @Param("lastId") Long lastId,
+                                @Param("lastId") String lastId,
                                 @Param("size") int size);
 
     @Modifying
     @Query("UPDATE EventBill e " +
             "SET e.isDeleted = :status " +
-            "WHERE e.event.id = :eventId ")
+            "WHERE e.event.ulid = :eventId ")
     int updateIsDeletedByEventId(@Param("status") Boolean status,
-                                 @Param("eventId") Long eventId);
+                                 @Param("eventId") String eventId);
 }

--- a/src/main/java/swm/backstage/movis/domain/event_bill/service/EventBillManager.java
+++ b/src/main/java/swm/backstage/movis/domain/event_bill/service/EventBillManager.java
@@ -14,7 +14,7 @@ public class EventBillManager {
      * 출금 여러개 isDeleted 수정
      * */
     @Transactional
-    public int updateIsDeleted(Long eventId){
+    public int updateIsDeleted(String eventId){
         return eventBillRepository.updateIsDeletedByEventId(Boolean.TRUE,eventId);
     }
 

--- a/src/main/java/swm/backstage/movis/domain/event_bill/service/EventBillService.java
+++ b/src/main/java/swm/backstage/movis/domain/event_bill/service/EventBillService.java
@@ -37,8 +37,8 @@ public class EventBillService {
     @Transactional
     public void createEventBillByInput(String eventId, EventBillInputReqDto dto) {
         Event event = eventService.getEventByUuid(eventId);
-        AccountBook accountBook = accountBookService.getAccountBookByClubId(event.getClub().getUuid());
-        EventBill eventBill = eventBillRepository.save(new EventBill(UUID.randomUUID().toString(), dto, event.getClub(), event));
+        AccountBook accountBook = accountBookService.getAccountBookByClubId(event.getClub().getUlid());
+        EventBill eventBill = eventBillRepository.save(new EventBill(dto, event.getClub(), event));
         accountBook.updateBalance(dto.getPaidAmount());
         accountBook.updateClassifiedWithdrawal(dto.getPaidAmount());
         event.updateBalance(dto.getPaidAmount());
@@ -49,7 +49,7 @@ public class EventBillService {
      */
     @Transactional
     public void createEventBill(EventBillCreateReqDto eventBillCreateReqDto) {
-        EventBill eventBill = eventBillRepository.save(new EventBill(UUID.randomUUID().toString(), eventBillCreateReqDto, clubService.getClubByUuId(eventBillCreateReqDto.getClubId())));
+        EventBill eventBill = eventBillRepository.save(new EventBill(eventBillCreateReqDto, clubService.getClubByUuId(eventBillCreateReqDto.getClubId())));
         AccountBook accountBook = accountBookService.getAccountBookByClubId(eventBillCreateReqDto.getClubId());
         accountBook.updateUnClassifiedWithdrawal(eventBillCreateReqDto.getAmount());
         accountBook.updateBalance(eventBillCreateReqDto.getAmount());
@@ -57,7 +57,7 @@ public class EventBillService {
     }
 
     public EventBill getEventBillByUuid(String eventBillId) {
-        return eventBillRepository.findByUuid(eventBillId).orElseThrow(() -> new BaseException("eventBill is not found", ErrorCode.ELEMENT_NOT_FOUND));
+        return eventBillRepository.findByUlid(eventBillId).orElseThrow(() -> new BaseException("eventBill is not found", ErrorCode.ELEMENT_NOT_FOUND));
     }
 
     @Transactional
@@ -76,10 +76,10 @@ public class EventBillService {
         Event event = eventService.getEventByUuid(eventId);
         List<EventBill> eventBillList;
         if (lastId.equals("first")) {
-            eventBillList = eventBillRepository.getFirstPage(event.getId(), lastPaidAt, size + 1);
+            eventBillList = eventBillRepository.getFirstPage(event.getUlid(), lastPaidAt, size + 1);
         } else {
             EventBill eventBill = getEventBillByUuid(lastId);
-            eventBillList = eventBillRepository.getNextPage(event.getId(), lastPaidAt, eventBill.getId(), size + 1);
+            eventBillList = eventBillRepository.getNextPage(event.getUlid(), lastPaidAt, eventBill.getUlid(), size + 1);
         }
 
         //하나 추가해서 조회한거 삭제해주기

--- a/src/main/java/swm/backstage/movis/domain/event_member/EventMember.java
+++ b/src/main/java/swm/backstage/movis/domain/event_member/EventMember.java
@@ -1,6 +1,7 @@
 package swm.backstage.movis.domain.event_member;
 
 
+import com.github.f4b6a3.ulid.UlidCreator;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -18,12 +19,11 @@ import java.util.List;
 @Getter
 public class EventMember extends DateTimeField {
 
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
 
-    @Column(unique = true, nullable = false, length = 36)
-    private String uuid;
+
+    @Id
+    @Column(unique = true, nullable = false, length = 26)
+    private String ulid;
 
     private Long amountToPay;
 
@@ -45,8 +45,8 @@ public class EventMember extends DateTimeField {
         this.isPaid = true;
     }
 
-    public EventMember(String uuid, Member member, Event event) {
-        this.uuid = uuid;
+    public EventMember( Member member, Event event) {
+        this.ulid = UlidCreator.getUlid().toString();
         this.member = member;
         this.event = event;
         isPaid = false;

--- a/src/main/java/swm/backstage/movis/domain/event_member/dto/EventMemberListElementDto.java
+++ b/src/main/java/swm/backstage/movis/domain/event_member/dto/EventMemberListElementDto.java
@@ -12,7 +12,7 @@ public class EventMemberListElementDto {
     private Long amountToPay;
 
     public EventMemberListElementDto(EventMember eventMember) {
-        this.eventMemberId = eventMember.getUuid();
+        this.eventMemberId = eventMember.getUlid();
         this.isPaid = eventMember.getIsPaid();
         this.amountToPay = eventMember.getAmountToPay();
     }

--- a/src/main/java/swm/backstage/movis/domain/event_member/repository/EventMemberJdbcRepository.java
+++ b/src/main/java/swm/backstage/movis/domain/event_member/repository/EventMemberJdbcRepository.java
@@ -17,16 +17,16 @@ public class EventMemberJdbcRepository {
 
     public void bulkSave(List<EventMember> memberList) {
         String sql = "INSERT INTO event_member " +
-                "(uuid, amount_to_pay, is_paid ,member_id, event_id, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?)";
+                "(ulid, amount_to_pay, is_paid ,member_id, event_id, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?)";
         jdbcTemplate.batchUpdate(sql, new BatchPreparedStatementSetter() {
             @Override
             public void setValues(PreparedStatement ps, int i) throws SQLException {
                 EventMember member = memberList.get(i);
-                ps.setString(1, member.getUuid());
+                ps.setString(1, member.getUlid());
                 ps.setLong(2, member.getAmountToPay());
                 ps.setBoolean(3, member.getIsPaid());
-                ps.setLong(4, member.getMember().getId());
-                ps.setLong(5, member.getEvent().getId());
+                ps.setString(4, member.getMember().getUlid());
+                ps.setString(5, member.getEvent().getUlid());
                 ps.setObject(6, LocalDateTime.now());
                 ps.setObject(7, LocalDateTime.now());
             }

--- a/src/main/java/swm/backstage/movis/domain/event_member/repository/EventMemberJpaRepository.java
+++ b/src/main/java/swm/backstage/movis/domain/event_member/repository/EventMemberJpaRepository.java
@@ -7,8 +7,8 @@ import swm.backstage.movis.domain.event_member.EventMember;
 import java.util.List;
 import java.util.Optional;
 
-public interface EventMemberJpaRepository extends JpaRepository<EventMember, Long> {
-    Optional<EventMember> findByUuid(String eventId);
+public interface EventMemberJpaRepository extends JpaRepository<EventMember, String> {
+    Optional<EventMember> findByUlid(String eventMemberId);
 
     Optional<EventMember> findByEventAndMemberName(Event event, String memberName);
 

--- a/src/main/java/swm/backstage/movis/domain/event_member/service/EventMemberService.java
+++ b/src/main/java/swm/backstage/movis/domain/event_member/service/EventMemberService.java
@@ -30,7 +30,7 @@ public class EventMemberService {
 
     @Transactional
     public EventMember getEventMemberByUuid(String eventMemberId) {
-        return eventMemberJpaRepository.findByUuid(eventMemberId)
+        return eventMemberJpaRepository.findByUlid(eventMemberId)
                 .orElseThrow(()->new BaseException("account book is not found", ErrorCode.ELEMENT_NOT_FOUND));
     }
 
@@ -38,15 +38,15 @@ public class EventMemberService {
     public void addEventMembers(EventMemberListReqDto eventMemberListReqDto) {
         Event event = eventService.getEventByUuid(eventMemberListReqDto.getEventId());
 
-        Set<Long> memberSet = event.getEventMembers().stream()
-                .map(eventMember -> eventMember.getMember().getId())
+        Set<String> memberSet = event.getEventMembers().stream()
+                .map(eventMember -> eventMember.getMember().getUlid())
                 .collect(Collectors.toSet());
 
 
         eventMemberJdbcRepository.bulkSave(
                 memberService.getMemberListByUuids(eventMemberListReqDto.getEventMemberIdList()).stream()
-                        .filter(member -> !memberSet.contains(member.getId()))
-                        .map(member->new EventMember(UUID.randomUUID().toString(),member,event))
+                        .filter(member -> !memberSet.contains(member.getUlid()))
+                        .map(member->new EventMember(member,event))
                         .toList()
         );
     }
@@ -67,7 +67,7 @@ public class EventMemberService {
         if(eventMember == null){
             return null;
         }
-        return eventMember.getUuid();
+        return eventMember.getUlid();
     }
 
 

--- a/src/main/java/swm/backstage/movis/domain/fee/Fee.java
+++ b/src/main/java/swm/backstage/movis/domain/fee/Fee.java
@@ -1,6 +1,7 @@
 package swm.backstage.movis.domain.fee;
 
 
+import com.github.f4b6a3.ulid.UlidCreator;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -16,17 +17,14 @@ import java.time.LocalDateTime;
 @Entity
 @Table(name = "fee", indexes = {
         @Index(name = "idx_event_id", columnList = "event_id"),
-        @Index(name = "idx_event_id_fee_id", columnList = "event_id, id")})
+        @Index(name = "idx_event_id_fee_id", columnList = "event_id, ulid")})
 @Getter
 @NoArgsConstructor
 public class Fee {
 
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
-
-    @Column(nullable = false, unique = true)
-    private String uuid;
+    @Column(nullable = false, unique = true, length = 26)
+    private String ulid;
 
     private Long paidAmount;
     private LocalDateTime paidAt;
@@ -51,8 +49,8 @@ public class Fee {
 
 
 
-    public Fee(String uuid, FeeReqDto feeReqDto, Club club) {
-        this.uuid = uuid;
+    public Fee(FeeReqDto feeReqDto, Club club) {
+        this.ulid = UlidCreator.getUlid().toString();
         this.paidAmount = feeReqDto.getPaidAmount();
         this.paidAt = feeReqDto.getPaidAt();
         this.name = feeReqDto.getName();
@@ -60,8 +58,8 @@ public class Fee {
         this.isDeleted = false;
     }
 
-    public Fee(String uuid, FeeReqDto feeReqDto, Club club, EventMember eventMember) {
-        this.uuid = uuid;
+    public Fee(FeeReqDto feeReqDto, Club club, EventMember eventMember) {
+        this.ulid = UlidCreator.getUlid().toString();
         this.paidAmount = feeReqDto.getPaidAmount();
         this.paidAt = feeReqDto.getPaidAt();
         this.name = feeReqDto.getName();
@@ -71,8 +69,8 @@ public class Fee {
         this.isDeleted = false;
     }
 
-    public Fee(String uuid, FeeInputReqDto feeInputReqDto, Club club, Event event, EventMember eventMember) {
-        this.uuid = uuid;
+    public Fee(FeeInputReqDto feeInputReqDto, Club club, Event event, EventMember eventMember) {
+        this.ulid = UlidCreator.getUlid().toString();
         this.paidAmount = feeInputReqDto.getPaidAmount();
         this.paidAt = feeInputReqDto.getPaidAt();
         this.name = feeInputReqDto.getName();

--- a/src/main/java/swm/backstage/movis/domain/fee/dto/FeeGetPagingElementResDto.java
+++ b/src/main/java/swm/backstage/movis/domain/fee/dto/FeeGetPagingElementResDto.java
@@ -8,12 +8,12 @@ import swm.backstage.movis.domain.fee.Fee;
 @Getter
 @NoArgsConstructor
 public class FeeGetPagingElementResDto {
-    private String uuid;
+    private String ulid;
     private String name;
     private Long amount;
 
     public FeeGetPagingElementResDto(Fee fee) {
-        this.uuid = fee.getUuid();
+        this.ulid = fee.getUlid();
         this.name = fee.getName();
         this.amount =fee.getPaidAmount();
     }

--- a/src/main/java/swm/backstage/movis/domain/fee/repository/FeeRepository.java
+++ b/src/main/java/swm/backstage/movis/domain/fee/repository/FeeRepository.java
@@ -10,36 +10,36 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
-public interface FeeRepository extends JpaRepository<Fee, Long> {
+public interface FeeRepository extends JpaRepository<Fee, String> {
 
 
-    Optional<Fee> findByUuid(String id);
+    Optional<Fee> findByUlid(String id);
 
     // 1 회차용
     @Query("SELECT f FROM Fee f " +
-            "WHERE f.event.id = :eventId " +
+            "WHERE f.event.ulid = :eventId " +
             "AND f.paidAt <= :lastPaidAt " +
-            "ORDER BY f.id DESC " +
+            "ORDER BY f.ulid DESC " +
             "LIMIT :size")
-    List<Fee> getFirstPage(@Param("eventId") Long eventId,
+    List<Fee> getFirstPage(@Param("eventId") String eventId,
                            @Param("lastPaidAt") LocalDateTime lastPaidAt,
                            @Param("size") int size);
 
     // n 회차용
     @Query("SELECT f FROM Fee f " +
-            "WHERE f.event.id = :eventId AND f.id < :lastId  " +
-            "AND ((f.paidAt = :lastPaidAt AND f.id > :lastId) OR (f.paidAt < :lastPaidAt)) " +
-            "ORDER BY f.id DESC " +
+            "WHERE f.event.ulid = :eventId AND f.ulid < :lastId  " +
+            "AND ((f.paidAt = :lastPaidAt AND f.ulid> :lastId) OR (f.paidAt < :lastPaidAt)) " +
+            "ORDER BY f.ulid DESC " +
             "LIMIT :size")
-    List<Fee> getNextPageByEventIdAndLastId(@Param("eventId") Long eventId,
+    List<Fee> getNextPageByEventIdAndLastId(@Param("eventId") String eventId,
                                             @Param("lastPaidAt") LocalDateTime lastPaidAt,
-                                            @Param("lastId") Long lastId,
+                                            @Param("lastId") String lastId,
                                             @Param("size") int size);
 
     @Modifying
     @Query("UPDATE Fee f " +
             "SET f.isDeleted = :status " +
-            "WHERE f.event.id = :eventId ")
+            "WHERE f.event.ulid = :eventId ")
     int updateIsDeletedByEventId(@Param("status") Boolean status,
-                                 @Param("eventId") Long eventId);
+                                 @Param("eventId") String eventId);
 }

--- a/src/main/java/swm/backstage/movis/domain/fee/service/FeeManager.java
+++ b/src/main/java/swm/backstage/movis/domain/fee/service/FeeManager.java
@@ -15,7 +15,7 @@ public class FeeManager {
      * 입금 여러개 isDeleted 수정
      * */
     @Transactional
-    public int updateIsDeleted(Long eventId){
+    public int updateIsDeleted(String eventId){
         return feeRepository.updateIsDeletedByEventId(Boolean.TRUE,eventId);
     }
 }

--- a/src/main/java/swm/backstage/movis/domain/member/Member.java
+++ b/src/main/java/swm/backstage/movis/domain/member/Member.java
@@ -1,6 +1,7 @@
 package swm.backstage.movis.domain.member;
 
 
+import com.github.f4b6a3.ulid.UlidCreator;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -16,22 +17,19 @@ import java.util.List;
 @Entity
 @Table(name = "member",
         indexes = {
-                @Index(name = "idx_name_club_uuid", columnList = "name, club_uuid")
+                @Index(name = "idx_name_club_uuid", columnList = "name, club_id")
         },
         uniqueConstraints = {
-                @UniqueConstraint(name = "unique_name_club_uuid", columnNames = {"name", "club_uuid"})
+                @UniqueConstraint(name = "unique_name_club_uuid", columnNames = {"name", "club_id"})
         })
 @NoArgsConstructor
 @Getter
 public class Member extends DateTimeField {
 
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "id")
-    private Long id;
 
-    @Column(unique = true, nullable = false, length = 36)
-    private String uuid;
+    @Id
+    @Column(unique = true, nullable = false, length = 26)
+    private String ulid;
 
     @Column(unique = true, name = "name", nullable = false, length = 255)
     private String name;
@@ -48,9 +46,6 @@ public class Member extends DateTimeField {
     @Column(name = "deleted_at", nullable = true)
     private LocalDateTime deletedAt;
 
-    @Column(name = "club_uuid", length = 36)
-    private String clubUuid;
-
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "club_id")
     private Club club;
@@ -58,10 +53,9 @@ public class Member extends DateTimeField {
     @OneToMany(mappedBy = "member", fetch = FetchType.LAZY, cascade = {CascadeType.PERSIST, CascadeType.REMOVE})
     private List<EventMember> eventMembers = new ArrayList<>();
 
-    public Member(String uuid, Club club, MemberCreateReqDto memberCreateReqDto) {
-        this.uuid = uuid;
+    public Member(Club club, MemberCreateReqDto memberCreateReqDto) {
+        this.ulid = UlidCreator.getUlid().toString();
         this.club = club;
-        this.clubUuid = club.getUuid();
         this.name = memberCreateReqDto.getName();
         this.phoneNo = memberCreateReqDto.getPhoneNo();
         this.isEnrolled = Boolean.TRUE;

--- a/src/main/java/swm/backstage/movis/domain/member/dto/MemberGetElementResDto.java
+++ b/src/main/java/swm/backstage/movis/domain/member/dto/MemberGetElementResDto.java
@@ -20,8 +20,8 @@ public class MemberGetElementResDto {
     private LocalDateTime updatedAt;
 
     public MemberGetElementResDto(Member member) {
-        this.memberId = member.getUuid();
-        this.clubId = member.getClub().getUuid();
+        this.memberId = member.getUlid();
+        this.clubId = member.getClub().getUlid();
         this.name = member.getName();
         this.phoneNo = member.getPhoneNo();
         this.isDeleted = member.getIsDeleted();

--- a/src/main/java/swm/backstage/movis/domain/member/repository/MemberJdbcRepository.java
+++ b/src/main/java/swm/backstage/movis/domain/member/repository/MemberJdbcRepository.java
@@ -23,17 +23,17 @@ public class MemberJdbcRepository {
     @Transactional
     public void bulkSave(List<Member> memberList) {
         String sql = "INSERT INTO member " +
-                "(uuid, name, phone_no ,is_enrolled, is_deleted, club_id, created_at, updated_at, deleted_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?,?)";
+                "(ulid, name, phone_no ,is_enrolled, is_deleted, club_id, created_at, updated_at, deleted_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?,?)";
         jdbcTemplate.batchUpdate(sql, new BatchPreparedStatementSetter() {
             @Override
             public void setValues(PreparedStatement ps, int i) throws SQLException {
                 Member member = memberList.get(i);
-                ps.setString(1, member.getUuid());
+                ps.setString(1, member.getUlid());
                 ps.setString(2, member.getName());
                 ps.setString(3, member.getPhoneNo());
                 ps.setBoolean(4, member.getIsEnrolled());
                 ps.setBoolean(5, member.getIsDeleted());
-                ps.setLong(6, member.getClub().getId());
+                ps.setString(6, member.getClub().getUlid());
                 ps.setObject(7, LocalDateTime.now());
                 ps.setObject(8, LocalDateTime.now());
                 ps.setObject(9, null);

--- a/src/main/java/swm/backstage/movis/domain/member/repository/MemberJpaRepository.java
+++ b/src/main/java/swm/backstage/movis/domain/member/repository/MemberJpaRepository.java
@@ -8,10 +8,10 @@ import swm.backstage.movis.domain.member.Member;
 import java.util.List;
 import java.util.Optional;
 
-public interface MemberJpaRepository extends JpaRepository<Member, Long> {
+public interface MemberJpaRepository extends JpaRepository<Member, String> {
     Boolean existsByClubAndPhoneNo(Club clubId, String phoneNo);
-    Boolean existsByNameAndClub_Uuid(String name, String clubUid);
+    Boolean existsByNameAndClub_Ulid(String name, String clubUid);
     List<Member> findAllByClub(Club club);
-    List<Member> findAllByUuidIn(List<String> uuids);
+    List<Member> findAllByUlidIn(List<String> ulids);
     Optional<Member> findByClubAndNameAndPhoneNo(Club club, String name, String phoneNo);
 }

--- a/src/main/java/swm/backstage/movis/domain/member/service/MemberService.java
+++ b/src/main/java/swm/backstage/movis/domain/member/service/MemberService.java
@@ -41,18 +41,18 @@ public class MemberService {
         // memberCreateListDto에 받아온 Member 중복 비교
         List<Member> memberList =  memberCreateListDto.getMemberList().stream()
                 .filter(memberCreateDto -> !existMemberSet.contains(memberCreateDto.getPhoneNo()+"+"+memberCreateDto.getName()))
-                .map(memberCreateDto -> new Member(UUID.randomUUID().toString(),club,memberCreateDto))
+                .map(memberCreateDto -> new Member(club,memberCreateDto))
                 .toList();
 
         memberJdbcRepository.bulkSave(memberList);
     }
 
     public Boolean existedByNameAndClubUuid(String name, String clubId){
-        return memberJpaRepository.existsByNameAndClub_Uuid(name, clubId);
+        return memberJpaRepository.existsByNameAndClub_Ulid(name, clubId);
     }
     public void create(String clubUid, MemberCreateReqDto memberCreateReqDto) {
         Club club = clubService.getClubByUuId(clubUid);
-        Member member = new Member(UUID.randomUUID().toString(), club, memberCreateReqDto);
+        Member member = new Member( club, memberCreateReqDto);
         memberJpaRepository.save(member);
     }
 
@@ -62,7 +62,7 @@ public class MemberService {
     }
 
     public List<Member> getMemberListByUuids(List<String> uuids) {
-        return memberJpaRepository.findAllByUuidIn(uuids);
+        return memberJpaRepository.findAllByUlidIn(uuids);
     }
 
     public boolean isMemberExist(String clubId, String name, String phoneNo) {

--- a/src/main/java/swm/backstage/movis/domain/transaction_history/TransactionHistory.java
+++ b/src/main/java/swm/backstage/movis/domain/transaction_history/TransactionHistory.java
@@ -1,6 +1,7 @@
 package swm.backstage.movis.domain.transaction_history;
 
 
+import com.github.f4b6a3.ulid.UlidCreator;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -14,20 +15,18 @@ import java.time.LocalDateTime;
 @Entity
 @Table(name = "transaction_history", indexes = {
         @Index(name = "event_id_paid_at", columnList = "event_id, paid_at"),
-        @Index(name = "idx_event_id_paid_at_th_id", columnList = "event_id, paid_at , id"),
+        @Index(name = "idx_event_id_paid_at_th_id", columnList = "event_id, paid_at , ulid"),
         @Index(name = "club_id_paid_at", columnList = "club_id, paid_at"),
-        @Index(name = "idx_club_id_paid_at_th_id", columnList = "club_id, paid_at , id")
+        @Index(name = "idx_club_id_paid_at_th_id", columnList = "club_id, paid_at , ulid")
 })
 @NoArgsConstructor
 @Getter
 public class TransactionHistory {
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
 
-    @Column(nullable = false, unique = true, length = 36)
-    private String uuid;
-    private String elementUuid;
+    @Id
+    @Column(nullable = false, unique = true, length = 26)
+    private String ulid;
+    private String elementUlid;
 
     private String name;
     private Long amount;
@@ -46,10 +45,10 @@ public class TransactionHistory {
     @JoinColumn(name = "club_id")
     private Club club;
 
-    public TransactionHistory(String uuid, TransactionHistoryCreateDto dto) {
+    public TransactionHistory( TransactionHistoryCreateDto dto) {
         this.club =dto.getClub();
-        this.uuid = uuid;
-        this.elementUuid = dto.getElementUuid();
+        this.ulid = UlidCreator.getUlid().toString();
+        this.elementUlid = dto.getElementUlid();
         this.name = dto.getName();
         this.amount = dto.getAmount();
         this.event = dto.getEvent();

--- a/src/main/java/swm/backstage/movis/domain/transaction_history/dto/TransactionHistoryCreateDto.java
+++ b/src/main/java/swm/backstage/movis/domain/transaction_history/dto/TransactionHistoryCreateDto.java
@@ -15,7 +15,7 @@ import java.time.LocalDateTime;
 public class TransactionHistoryCreateDto {
 
     private Club club;
-    private String elementUuid;
+    private String elementUlid;
     private String name;
     private Long amount;
     private LocalDateTime paidAt;
@@ -23,10 +23,10 @@ public class TransactionHistoryCreateDto {
     private TransactionStatus status;
     private Boolean isClassified;
 
-    public TransactionHistoryCreateDto(Club club, Event event, String elementUuid, String name, Long amount, LocalDateTime paidAt, TransactionStatus status, Boolean isClassified) {
+    public TransactionHistoryCreateDto(Club club, Event event, String elementUlid, String name, Long amount, LocalDateTime paidAt, TransactionStatus status, Boolean isClassified) {
         this.club = club;
         this.event = event;
-        this.elementUuid = elementUuid;
+        this.elementUlid = elementUlid;
         this.name = name;
         this.amount = amount;
         this.paidAt = paidAt;
@@ -39,7 +39,7 @@ public class TransactionHistoryCreateDto {
         return new TransactionHistoryCreateDto(
                 eventBill.getClub(),
                 eventBill.getEvent(),
-                eventBill.getUuid(),
+                eventBill.getUlid(),
                 eventBill.getPayName(),
                 eventBill.getAmount(),
                 eventBill.getPaidAt(),
@@ -50,7 +50,7 @@ public class TransactionHistoryCreateDto {
         return new TransactionHistoryCreateDto(
                 fee.getClub(),
                 fee.getEvent(),
-                fee.getUuid(),
+                fee.getUlid(),
                 fee.getName(),
                 fee.getPaidAmount(),
                 fee.getPaidAt(),

--- a/src/main/java/swm/backstage/movis/domain/transaction_history/dto/TransactionHistoryGetElementResDto.java
+++ b/src/main/java/swm/backstage/movis/domain/transaction_history/dto/TransactionHistoryGetElementResDto.java
@@ -17,8 +17,8 @@ public class TransactionHistoryGetElementResDto {
     private LocalDateTime paidAt;
 
     public TransactionHistoryGetElementResDto(TransactionHistory transactionHistory) {
-        this.transactionHistoryId = transactionHistory.getUuid();
-        this.elementId = transactionHistory.getElementUuid();
+        this.transactionHistoryId = transactionHistory.getUlid();
+        this.elementId = transactionHistory.getElementUlid();
         this.name = transactionHistory.getName();
         this.amount =transactionHistory.getAmount();
         this.paidAt = transactionHistory.getPaidAt();

--- a/src/main/java/swm/backstage/movis/domain/transaction_history/repository/TransactionHistoryRepository.java
+++ b/src/main/java/swm/backstage/movis/domain/transaction_history/repository/TransactionHistoryRepository.java
@@ -11,61 +11,61 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
-public interface TransactionHistoryRepository extends JpaRepository<TransactionHistory, Long> {
+public interface TransactionHistoryRepository extends JpaRepository<TransactionHistory, String> {
 
-    Optional<TransactionHistory> findByUuid(String uuid);
+    Optional<TransactionHistory> findByUlid(String ulid);
 
     // 1 회차용 Event로 조회
     @Query("SELECT th FROM TransactionHistory th " +
-            "WHERE th.event.id = :eventId " +
+            "WHERE th.event.ulid = :eventId " +
             "AND th.paidAt <= :lastPaidAt " +
-            "ORDER BY th.paidAt DESC, th.id ASC " +
+            "ORDER BY th.paidAt DESC, th.ulid ASC " +
             "LIMIT :size")
-    List<TransactionHistory> getFirstPageByEvent(@Param("eventId") Long eventId,
+    List<TransactionHistory> getFirstPageByEvent(@Param("eventId") String eventId,
                                           @Param("lastPaidAt") LocalDateTime lastPaidAt,
                                           @Param("size") int size);
 
     // n 회차용 Event로 조회
     @Query("SELECT th FROM TransactionHistory th " +
-            "WHERE th.event.id = :eventId " +
-            "AND ((th.paidAt = :lastPaidAt AND th.id > :lastId) OR (th.paidAt < :lastPaidAt)) " +
-            "ORDER BY th.paidAt DESC , th.id ASC " +
+            "WHERE th.event.ulid = :eventId " +
+            "AND ((th.paidAt = :lastPaidAt AND th.ulid > :lastId) OR (th.paidAt < :lastPaidAt)) " +
+            "ORDER BY th.paidAt DESC , th.ulid ASC " +
             "LIMIT :size")
-    List<TransactionHistory> getNextPageByEvent(@Param("eventId") Long eventId,
+    List<TransactionHistory> getNextPageByEvent(@Param("eventId") String eventId,
                                             @Param("lastPaidAt") LocalDateTime lastPaidAt,
-                                            @Param("lastId") Long lastId,
+                                            @Param("lastId") String lastId,
                                             @Param("size") int size);
 
     // 1 회차용 Club으로 조회
     @Query("SELECT th FROM TransactionHistory th " +
-            "WHERE th.club.id = :clubId " +
+            "WHERE th.club.ulid = :clubId " +
             "AND th.paidAt <= :lastPaidAt " +
-            "ORDER BY th.paidAt DESC, th.id ASC " +
+            "ORDER BY th.paidAt DESC, th.ulid ASC " +
             "LIMIT :size")
-    List<TransactionHistory> getFirstPageByClub(@Param("clubId") Long clubId,
+    List<TransactionHistory> getFirstPageByClub(@Param("clubId") String clubId,
                                                  @Param("lastPaidAt") LocalDateTime lastPaidAt,
                                                  @Param("size") int size);
 
     // n 회차용 Club으로 조회
     @Query("SELECT th FROM TransactionHistory th " +
-            "WHERE th.club.id = :clubId " +
-            "AND ((th.paidAt = :lastPaidAt AND th.id > :lastId) OR (th.paidAt < :lastPaidAt)) " +
-            "ORDER BY th.paidAt DESC , th.id ASC " +
+            "WHERE th.club.ulid = :clubId " +
+            "AND ((th.paidAt = :lastPaidAt AND th.ulid > :lastId) OR (th.paidAt < :lastPaidAt)) " +
+            "ORDER BY th.paidAt DESC , th.ulid ASC " +
             "LIMIT :size")
-    List<TransactionHistory> getNextPageByClub(@Param("clubId") Long clubId,
+    List<TransactionHistory> getNextPageByClub(@Param("clubId") String clubId,
                                                 @Param("lastPaidAt") LocalDateTime lastPaidAt,
-                                                @Param("lastId") Long lastId,
+                                                @Param("lastId") String lastId,
                                                 @Param("size") int size);
 
     @Modifying
     @Query("UPDATE TransactionHistory t " +
             "SET t.isDeleted = :status " +
-            "WHERE t.event.id = :eventId ")
+            "WHERE t.event.ulid = :eventId ")
     int updateIsDeletedByEventId(@Param("status") Boolean status,
-                                 @Param("eventId") Long eventId);
+                                 @Param("eventId") String eventId);
 
-    Optional<TransactionHistory> findByElementUuid(String elementUuid);
-    List<TransactionHistory> findAllByClubUuidAndIsClassifiedOrderByPaidAtDesc(String clubId, boolean isClassified);
-    Long countByClubUuidAndIsClassified(String clubUuid, boolean isClassified);
+    Optional<TransactionHistory> findByElementUlid(String elementUlid);
+    List<TransactionHistory> findAllByClubUlidAndIsClassifiedOrderByPaidAtDesc(String clubId, boolean isClassified);
+    Long countByClubUlidAndIsClassified(String clubId, boolean isClassified);
 
 }

--- a/src/main/java/swm/backstage/movis/domain/transaction_history/service/TransactionHistoryManager.java
+++ b/src/main/java/swm/backstage/movis/domain/transaction_history/service/TransactionHistoryManager.java
@@ -15,7 +15,7 @@ public class TransactionHistoryManager {
      * 입금 여러개 isDeleted 수정
      * */
     @Transactional
-    public int updateIsDeleted(Long eventId){
+    public int updateIsDeleted(String eventId){
         return transactionHistoryRepository.updateIsDeletedByEventId(Boolean.TRUE,eventId);
     }
 }

--- a/src/main/java/swm/backstage/movis/domain/transaction_history/service/TransactionHistoryService.java
+++ b/src/main/java/swm/backstage/movis/domain/transaction_history/service/TransactionHistoryService.java
@@ -29,7 +29,7 @@ public class TransactionHistoryService {
      * 거래내역 저장
      */
     public void saveTransactionHistory(TransactionHistoryCreateDto dto) {
-        transactionHistoryRepository.save(new TransactionHistory(UUID.randomUUID().toString(), dto));
+        transactionHistoryRepository.save(new TransactionHistory(dto));
     }
     /**
      * 전체 거래내역 페이징 (Event로)
@@ -38,11 +38,11 @@ public class TransactionHistoryService {
         Event event = eventService.getEventByUuid(eventId);
         List<TransactionHistory> transactionHistoryListList;
         if (lastId.equals("first")) {
-            transactionHistoryListList = transactionHistoryRepository.getFirstPageByEvent(event.getId(), lastPaidAt, size + 1);
+            transactionHistoryListList = transactionHistoryRepository.getFirstPageByEvent(event.getUlid(), lastPaidAt, size + 1);
         } else {
-            TransactionHistory transactionHistory = transactionHistoryRepository.findByUuid(lastId)
+            TransactionHistory transactionHistory = transactionHistoryRepository.findByUlid(lastId)
                     .orElseThrow(() -> new BaseException("TransactionHistory is not found", ErrorCode.ELEMENT_NOT_FOUND));
-            transactionHistoryListList = transactionHistoryRepository.getNextPageByEvent(event.getId(), lastPaidAt, transactionHistory.getId(), size + 1);
+            transactionHistoryListList = transactionHistoryRepository.getNextPageByEvent(event.getUlid(), lastPaidAt, transactionHistory.getUlid(), size + 1);
         }
 
         //하나 추가해서 조회한거 삭제해주기
@@ -62,11 +62,11 @@ public class TransactionHistoryService {
 
 
         if (lastId.equals("first")) {
-            transactionHistoryListList = transactionHistoryRepository.getFirstPageByClub(club.getId(), lastPaidAt, size + 1);
+            transactionHistoryListList = transactionHistoryRepository.getFirstPageByClub(club.getUlid(), lastPaidAt, size + 1);
         } else {
-            TransactionHistory transactionHistory = transactionHistoryRepository.findByUuid(lastId)
+            TransactionHistory transactionHistory = transactionHistoryRepository.findByUlid(lastId)
                     .orElseThrow(() -> new BaseException("TransactionHistory is not found", ErrorCode.ELEMENT_NOT_FOUND));
-            transactionHistoryListList = transactionHistoryRepository.getNextPageByClub(club.getId(), lastPaidAt, transactionHistory.getId(), size + 1);
+            transactionHistoryListList = transactionHistoryRepository.getNextPageByClub(club.getUlid(), lastPaidAt, transactionHistory.getElementUlid(), size + 1);
         }
 
         //하나 추가해서 조회한거 삭제해주기
@@ -80,7 +80,7 @@ public class TransactionHistoryService {
 
     @Transactional
     public void updateTransactionHistory(TransactionHistoryUpdateDto dto) {
-        TransactionHistory transactionHistory = transactionHistoryRepository.findByElementUuid(dto.getElementId())
+        TransactionHistory transactionHistory = transactionHistoryRepository.findByElementUlid(dto.getElementId())
                 .orElseThrow(()->new BaseException("TransactionHistory not found", ErrorCode.ELEMENT_NOT_FOUND));
         transactionHistory.updateTransactionHistory(dto.getEvent(), dto.getName());
     }
@@ -88,12 +88,12 @@ public class TransactionHistoryService {
      * 미분류 리스트 조회 ( not 페이징 )
      * */
     public List<TransactionHistory> getUnclassifiedTransactionHistory(String clubId) {
-        return transactionHistoryRepository.findAllByClubUuidAndIsClassifiedOrderByPaidAtDesc(clubId,false);
+        return transactionHistoryRepository.findAllByClubUlidAndIsClassifiedOrderByPaidAtDesc(clubId,false);
     }
     /**
      *  미분류 개수 조회
      * */
     public Long getTransactionHistoryCount(String clubId) {
-        return transactionHistoryRepository.countByClubUuidAndIsClassified(clubId,false);
+        return transactionHistoryRepository.countByClubUlidAndIsClassified(clubId,false);
     }
 }


### PR DESCRIPTION
# 이슈
- #80 

# 구현 기능

기존의 entity 구조는 id, uuid 로 구성되어있었는데 해당 부분에서 uuid는 사용되고 id는 사용되지않는데 이용하고 있었다. 따라서 club, event, member, eventMember, fee, eventBill, tansactionHistory 부분의 pk를 ulid로 통합하는 작업을 진행하였다.

# 구현 내용
 
pk를 결정하는데 우선적으로 생각한 것은 보안이었다. 따라서 인덱스에 PK가 들어가는 비용은 감수하고 시작하였다.

### 먼저 고려한 것은 UUID 였다.
지금 사용하는 UUID 4는 일단 무작위로 만들어져서 순서가 보장되지 않는다. 따라서 선택할 수 없다. (인덱스의 순차성 때문에)

UUID 1,2가 순서가 보장되는데
버전 1은  MAC 주소가 포함되어 하드웨어 정보가 노출될 수 있다는 문제가 있다.
버전 2는 로컬도메인 식별자를 포함하는 방식으로 Unix 시스템에서의 UID/GID등이 이에 해당한다.
이 부분도 개인정보 노출 위험이 있어 보안적으로 위험하다

UUID v7은 시간 기반 UUID로, 밀리초 단위의 타임스탬프를 포함합니다. 
크기 : 128비트 (16바이트)
순차적인 특성을 가지며 시간 순서 정렬이 가능하지만 표준화 되지 않았다는 단점이 존재한다.
Spring Boot에서도 공식적인 지원이 없고 Java 표준에도 없다. -> 라이브러리 안정성 및 장기적 유지 보수 보장이 어려움

### 따라서 ULID 사용을 고려하였다.
시간 기반 고유 식별자로 밀리초 단위의 타임 스탬프 포함
크기 : 128비트 크기지만 26자리의 base32문자열로 표현됨 (26자리)
앞 48비트는 타임스탬프, 뒤의 80비트는 랜덤값
26자리의 짧은 길이로 URL에 사용하기 적합하다.
또한 ULID 생성을 지원하는 라이브러리가 존재하며 Spring Boot 전용 라이브러리도 존재한다.

이런 이유로 UUID보다 ULID를 사용하는 것이 맞다고 생각하였고 ULID Creator 를 이용하여 진행하기로 결정하였다.
(snow flake나 tsid라는 선택지도 있었는데 해당 key generator의 경우 분산환경을 고려한 키 생성기 였습니다. 따라서 아직 분산환경까지 고려하지 않고 있어 선택지의 폭을 UUID와 ULID로 두었습니다.)


