### PR TITLE
[feat] issue-#84: eventMember 리스트 조회에 이름 항목 추가

### DIFF
--- a/src/main/java/swm/backstage/movis/domain/event_member/dto/EventMemberListElementDto.java
+++ b/src/main/java/swm/backstage/movis/domain/event_member/dto/EventMemberListElementDto.java
@@ -8,11 +8,13 @@ import swm.backstage.movis.domain.event_member.EventMember;
 @NoArgsConstructor
 public class EventMemberListElementDto {
     private String eventMemberId;
+    private String name;
     private Boolean isPaid;
     private Long amountToPay;
 
     public EventMemberListElementDto(EventMember eventMember) {
         this.eventMemberId = eventMember.getUlid();
+        this.name = eventMember.getMember().getName();
         this.isPaid = eventMember.getIsPaid();
         this.amountToPay = eventMember.getAmountToPay();
     }

--- a/src/test/java/swm/backstage/movis/hello/MemoryVisibilitySample.java
+++ b/src/test/java/swm/backstage/movis/hello/MemoryVisibilitySample.java
@@ -1,7 +1,10 @@
 package swm.backstage.movis.hello;
 
 
+import org.junit.jupiter.api.Disabled;
+
 // MemoryVisibility
+@Disabled
 public class MemoryVisibilitySample {
     private static volatile boolean flag = false;
     public static void main(String[] args) throws InterruptedException {


### PR DESCRIPTION
# 이슈
- #84 

# 구현 기능

프론트단에서 EventMember 리스트를 조회할때 이름이 필요하다는 요구사항에 맞게 API Response를 수정하였다. 

# 작업 시간
30 min
