### PR TITLE
[feat] issue-#89: 중복 검증 구현

### DIFF
--- a/src/main/java/swm/backstage/movis/domain/club_user/repository/ClubUserRepository.java
+++ b/src/main/java/swm/backstage/movis/domain/club_user/repository/ClubUserRepository.java
@@ -9,5 +9,8 @@ import java.util.Optional;
 public interface ClubUserRepository extends JpaRepository<ClubUser, Long> {
 
     Optional<ClubUser> findByIdentifierAndClub_Ulid(String identifier, String clubId);
+
+    boolean existsByIdentifierAndClub_Ulid(String identifier, String clubId);
+
     List<ClubUser> findAllByClub_Ulid(String clubId);
 }

--- a/src/main/java/swm/backstage/movis/domain/club_user/service/ClubUserService.java
+++ b/src/main/java/swm/backstage/movis/domain/club_user/service/ClubUserService.java
@@ -29,6 +29,11 @@ public class ClubUserService {
     public void createClubUser(ClubUserCreateReqDto clubUserCreateReqDto) {
         Club club = clubService.findClubByUuId(clubUserCreateReqDto.getClubId());
         User user = userService.findByIdentifier(clubUserCreateReqDto.getIdentifier()).orElseThrow(()-> new BaseException("Element Not Found", ErrorCode.ELEMENT_NOT_FOUND));
+
+        if(clubUserRepository.existsByIdentifierAndClub_Ulid(user.getIdentifier(), club.getUlid())){
+            throw new BaseException("해당 클럽에 이미 등록된 사용자입니다.", ErrorCode.DUPLICATE_CLUB_USER);
+        }
+
         ClubUser clubUser = new ClubUser(UUID.randomUUID().toString(), RoleType.ROLE_EXECUTIVE, user, club);
         clubUserRepository.save(clubUser);
     }

--- a/src/main/java/swm/backstage/movis/global/error/ErrorCode.java
+++ b/src/main/java/swm/backstage/movis/global/error/ErrorCode.java
@@ -21,7 +21,8 @@ public enum ErrorCode {
     DUPLICATE_USER("C010", "Duplicate User", DisplayType.POPUP),
     UNAUTHORIZED_PERMISSION("C011", "Unauthorized Permission", DisplayType.POPUP),
     UNAUTHENTICATED_REQUEST("C012", "Unauthenticated Request", DisplayType.POPUP),
-    DECRYPTION_FAILED("C013", "Decryption Failed", DisplayType.POPUP);
+    DECRYPTION_FAILED("C013", "Decryption Failed", DisplayType.POPUP),
+    DUPLICATE_CLUB_USER("C014", "Duplicate ClubUser", DisplayType.POPUP);
 
     private final String code;
     private final String message;


### PR DESCRIPTION
# 이슈
- [ClubUser 생성 시 중복 검증 #89](https://github.com/swm-backstage/movis-backend/issues/89)

# 구현 기능
- ClubUserService의 createClubUser에 중복 검증 로직을 추가
기존 ClubUserService의 getClubUser를 활용하기보다, repository에 existsByIdentifierAndClub_Ulid를 구현

# 작업 시간
10m
