### PR TITLE
[feat] issue/feature-#91: 모임, 입금, 출금 삭제 및 수정 기능 구현 + 조회로직 수정

### DIFF
--- a/src/main/java/swm/backstage/movis/domain/club/Club.java
+++ b/src/main/java/swm/backstage/movis/domain/club/Club.java
@@ -98,4 +98,8 @@ public class Club extends DateTimeField {
         clubUserList.add(clubUser);
     }
 
+    public void updateIsDeleted(Boolean isDeleted){
+        this.isDeleted = isDeleted;
+    }
+
 }

--- a/src/main/java/swm/backstage/movis/domain/club/controller/ClubController.java
+++ b/src/main/java/swm/backstage/movis/domain/club/controller/ClubController.java
@@ -12,7 +12,6 @@ import swm.backstage.movis.domain.auth.enums.PlatformType;
 import swm.backstage.movis.domain.auth.dto.AuthTokenDto;
 import swm.backstage.movis.domain.auth.dto.AuthenticationPrincipalDetails;
 import swm.backstage.movis.domain.auth.service.AuthTokenService;
-import swm.backstage.movis.domain.club.Club;
 import swm.backstage.movis.domain.club.dto.*;
 import swm.backstage.movis.domain.club.service.ClubService;
 import swm.backstage.movis.domain.member.service.MemberService;
@@ -88,5 +87,10 @@ public class ClubController {
     @PostMapping("/{clubId}/inviteCode")
     public String updateInviteCode(@PathVariable("clubId") String clubId){
         return clubService.updateInviteCode(clubId);
+    }
+
+    @DeleteMapping()
+    public void deleteClub(@RequestParam("clubId") String clubId){
+        clubService.deleteClub(clubId);
     }
 }

--- a/src/main/java/swm/backstage/movis/domain/club/repository/ClubRepository.java
+++ b/src/main/java/swm/backstage/movis/domain/club/repository/ClubRepository.java
@@ -7,7 +7,7 @@ import swm.backstage.movis.domain.club.Club;
 import java.util.Optional;
 
 public interface ClubRepository extends JpaRepository<Club, String> {
-    Optional<Club> findByUlidAndIsDeleted(String id, Boolean deleted);
-    Optional<Club> findByEntryCode(String entryCode);
-    Optional<Club> findByInviteCode(String inviteCode);
+    Optional<Club> findByUlidAndIsDeleted(String id, Boolean isDeleted);
+    Optional<Club> findByEntryCodeAndIsDeleted(String entryCode, Boolean isDeleted);
+    Optional<Club> findByInviteCodeAndIsDeleted(String inviteCode, Boolean isDeleted);
 }

--- a/src/main/java/swm/backstage/movis/domain/event/controller/EventController.java
+++ b/src/main/java/swm/backstage/movis/domain/event/controller/EventController.java
@@ -69,7 +69,7 @@ public class EventController {
     @DeleteMapping()
     public void deleteEvent(@RequestParam(name = "clubId") @Param("clubId") String clubId,
                             @RequestParam(name = "eventId") String eventId) {
-        eventService.deleteEvent(clubId,eventId);
+        eventManager.deleteEvent(clubId,eventId);
     }
 
 }

--- a/src/main/java/swm/backstage/movis/domain/event/service/EventManager.java
+++ b/src/main/java/swm/backstage/movis/domain/event/service/EventManager.java
@@ -1,17 +1,29 @@
 package swm.backstage.movis.domain.event.service;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import swm.backstage.movis.domain.accout_book.AccountBook;
+import swm.backstage.movis.domain.accout_book.service.AccountBookService;
 import swm.backstage.movis.domain.event.Event;
 import swm.backstage.movis.domain.event.dto.EventCreateReqDto;
+import swm.backstage.movis.domain.event_bill.service.EventBillManager;
 import swm.backstage.movis.domain.event_member.dto.EventMemberListReqDto;
 import swm.backstage.movis.domain.event_member.service.EventMemberService;
+import swm.backstage.movis.domain.fee.service.FeeManager;
+import swm.backstage.movis.domain.transaction_history.service.TransactionHistoryManager;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class EventManager {
     private final EventService eventService;
     private final EventMemberService eventMemberService;
+    private final AccountBookService accountBookService;
+    private final FeeManager feeManager;
+    private final EventBillManager eventBillManager;
+    private final TransactionHistoryManager transactionHistoryManager;
 
     public Event createEvent(EventCreateReqDto eventCreateReqDto) {
         // 1. event를 생성한다. (클럽id, 이벤트 이름, 입금기한, 입금금액)
@@ -20,5 +32,33 @@ public class EventManager {
         // 2. 생성된 event로 eventMemberList가 있다면 eventMemberList도 등록한다.
         eventMemberService.addEventMembers(new EventMemberListReqDto(event.getUlid(),eventCreateReqDto.getEventMemberIdList()));
         return event;
+    }
+
+    @Transactional
+    public void deleteEvent(String clubId, String eventId) {
+        log.info("deleteEvent Start");
+        //1. lock 걸고
+        AccountBook accountBook = accountBookService.getAccountBookByClubId(clubId);
+        log.info("Catch lock");
+
+        Event event = eventService.getEventByUuid(eventId);
+        event.updateIsDeleted(Boolean.TRUE);
+
+        log.info("이벤트 soft delete");
+
+        //2. deposit 관련 수정
+        feeManager.updateIsDeleted(event.getUlid());
+
+        log.info("deposit soft delete");
+
+        //3. eventBill 수정
+        eventBillManager.updateIsDeleted(event.getUlid());
+
+        log.info("eventBill soft delete");
+
+        //4. transactionHistory 수정
+        transactionHistoryManager.updateIsDeleted(event.getUlid());
+
+        log.info("transactionHistory soft delete");
     }
 }

--- a/src/main/java/swm/backstage/movis/domain/event/service/EventService.java
+++ b/src/main/java/swm/backstage/movis/domain/event/service/EventService.java
@@ -37,9 +37,6 @@ public class EventService {
     private final EventRepository eventRepository;
     private final ClubService clubService;
     private final AccountBookService accountBookService;
-    private final FeeManager feeManager;
-    private final EventBillManager eventBillManager;
-    private final TransactionHistoryManager transactionHistoryManager;
 
     @Transactional
     public Event createEvent(EventCreateReqDto eventCreateReqDto) {
@@ -113,34 +110,4 @@ public class EventService {
         event.updateEvent(eventUpdateReqDto);
         return event;
     }
-
-    @Transactional
-    public void deleteEvent(String clubId, String eventId) {
-        log.info("deleteEvent Start");
-        //1. lock 걸고
-        AccountBook accountBook = accountBookService.getAccountBookByClubId(clubId);
-        log.info("Catch lock");
-
-        Event event = getEventByUuid(eventId);
-        event.updateIsDeleted(Boolean.TRUE);
-
-        log.info("이벤트 soft delete");
-
-        //2. deposit 관련 수정
-        feeManager.updateIsDeleted(event.getUlid());
-
-        log.info("deposit soft delete");
-
-        //3. eventBill 수정
-        eventBillManager.updateIsDeleted(event.getUlid());
-
-        log.info("eventBill soft delete");
-
-        //4. transactionHistory 수정
-        transactionHistoryManager.updateIsDeleted(event.getUlid());
-
-        log.info("transactionHistory soft delete");
-    }
-
-
 }

--- a/src/main/java/swm/backstage/movis/domain/event_bill/EventBill.java
+++ b/src/main/java/swm/backstage/movis/domain/event_bill/EventBill.java
@@ -1,6 +1,5 @@
 package swm.backstage.movis.domain.event_bill;
 
-
 import com.github.f4b6a3.ulid.UlidCreator;
 import jakarta.persistence.*;
 import lombok.Getter;
@@ -10,6 +9,7 @@ import swm.backstage.movis.domain.club.Club;
 import swm.backstage.movis.domain.event.Event;
 import swm.backstage.movis.domain.event_bill.dto.EventBillCreateReqDto;
 import swm.backstage.movis.domain.event_bill.dto.EventBillInputReqDto;
+import swm.backstage.movis.domain.event_bill.dto.EventBillUpdateContentReqDto;
 import swm.backstage.movis.global.common.DateTimeField;
 
 import java.time.LocalDateTime;
@@ -37,7 +37,6 @@ public class EventBill extends DateTimeField {
 
     @Column(name = "image", length = 500)
     private String image;
-
 
     @Setter
     @Column(length = 100)
@@ -78,5 +77,13 @@ public class EventBill extends DateTimeField {
 
     public void updateIsDeleted(Boolean isDeleted) {
         this.isDeleted = isDeleted;
+    }
+
+    public void updateContent(EventBillUpdateContentReqDto dto) {
+        this.payName = dto.getPayName();
+        this.amount = dto.getAmount();
+        this.paidAt = dto.getPaidAt();
+        this.image = dto.getImage();
+        this.explanation = dto.getExplanation();
     }
 }

--- a/src/main/java/swm/backstage/movis/domain/event_bill/controller/EventBillController.java
+++ b/src/main/java/swm/backstage/movis/domain/event_bill/controller/EventBillController.java
@@ -68,5 +68,20 @@ public class EventBillController {
     public EventBillGetResDto createEventBillExplanation(@RequestBody @Param("eventBIllCreateExplanationReqDto") EventBIllCreateExplanationReqDto  eventBIllCreateExplanationReqDto){
         return new EventBillGetResDto(eventBillService.createEventBillExplanation(eventBIllCreateExplanationReqDto));
     }
+    /**
+     * 출금 내역 수정 (미분류만)
+     * */
+    @PatchMapping("/content")
+    public void updateEventBillContent(@RequestParam("eventBillId")String eventBillId,
+                                       @RequestBody EventBillUpdateContentReqDto dto){
+        eventBillService.updateEventBillContent(eventBillId, dto);
+    }
+    /**
+     * 출금 내역 삭제
+     * */
+    @DeleteMapping
+    public void deleteEventBill(@RequestParam("eventBillId")String eventBillId) {
+        eventBillService.deleteEventBill(eventBillId);
+    }
 
 }

--- a/src/main/java/swm/backstage/movis/domain/event_bill/dto/EventBillUpdateContentReqDto.java
+++ b/src/main/java/swm/backstage/movis/domain/event_bill/dto/EventBillUpdateContentReqDto.java
@@ -1,0 +1,16 @@
+package swm.backstage.movis.domain.event_bill.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor
+public class EventBillUpdateContentReqDto {
+    private Long amount;
+    private LocalDateTime paidAt;
+    private String payName;
+    private String explanation;
+    private String image;
+}

--- a/src/main/java/swm/backstage/movis/domain/event_bill/repository/EventBillRepository.java
+++ b/src/main/java/swm/backstage/movis/domain/event_bill/repository/EventBillRepository.java
@@ -11,33 +11,39 @@ import java.util.List;
 import java.util.Optional;
 
 public interface EventBillRepository extends JpaRepository<EventBill, String> {
-    Optional<EventBill> findByUlid(String ulid);
+    Optional<EventBill> findByUlidAndIsDeleted(String ulid,Boolean isDeleted);
 
     // 1 회차용
     @Query("SELECT eb FROM EventBill eb " +
             "WHERE eb.event.ulid = :eventId " +
             "AND eb.paidAt <= :lastPaidAt " +
+            "AND eb.isDeleted = :isDeleted " +
             "ORDER BY eb.paidAt DESC , eb.ulid ASC " +
             "LIMIT :size")
     List<EventBill> getFirstPage(@Param("eventId") String eventId,
                                  @Param("lastPaidAt") LocalDateTime lastPaidAt,
+                                 @Param("isDeleted") Boolean isDeleted,
                                  @Param("size") int size);
 
     // n 회차용
     @Query("SELECT eb FROM EventBill eb " +
             "WHERE eb.event.ulid = :eventId AND eb.ulid < :lastId  " +
             "AND ((eb.paidAt = :lastPaidAt AND eb.ulid > :lastId) OR (eb.paidAt < :lastPaidAt)) " +
+            "AND eb.isDeleted = :isDeleted " +
             "ORDER BY eb.paidAt DESC , eb.ulid ASC " +
             "LIMIT :size")
     List<EventBill> getNextPage(@Param("eventId") String eventId,
                                 @Param("lastPaidAt") LocalDateTime lastPaidAt,
                                 @Param("lastId") String lastId,
+                                @Param("isDeleted") Boolean isDeleted,
                                 @Param("size") int size);
 
     @Modifying
     @Query("UPDATE EventBill e " +
             "SET e.isDeleted = :status " +
-            "WHERE e.event.ulid = :eventId ")
+            "WHERE e.event.ulid = :eventId " +
+            "AND e.isDeleted = :isDeleted ")
     int updateIsDeletedByEventId(@Param("status") Boolean status,
-                                 @Param("eventId") String eventId);
+                                 @Param("eventId") String eventId,
+                                 @Param("isDeleted") Boolean isDeleted);
 }

--- a/src/main/java/swm/backstage/movis/domain/event_bill/service/EventBillManager.java
+++ b/src/main/java/swm/backstage/movis/domain/event_bill/service/EventBillManager.java
@@ -15,7 +15,7 @@ public class EventBillManager {
      * */
     @Transactional
     public int updateIsDeleted(String eventId){
-        return eventBillRepository.updateIsDeletedByEventId(Boolean.TRUE,eventId);
+        return eventBillRepository.updateIsDeletedByEventId(Boolean.TRUE,eventId, Boolean.FALSE);
     }
 
 }

--- a/src/main/java/swm/backstage/movis/domain/fee/Fee.java
+++ b/src/main/java/swm/backstage/movis/domain/fee/Fee.java
@@ -11,6 +11,7 @@ import swm.backstage.movis.domain.event.Event;
 import swm.backstage.movis.domain.event_member.EventMember;
 import swm.backstage.movis.domain.fee.dto.FeeInputReqDto;
 import swm.backstage.movis.domain.fee.dto.FeeReqDto;
+import swm.backstage.movis.domain.fee.dto.FeeUpdateContentReqDto;
 
 import java.time.LocalDateTime;
 
@@ -85,6 +86,13 @@ public class Fee {
         this.eventMember = eventMember;
         this.event = eventMember.getEvent();
         this.name = feeReqDto.getName();
+    }
+
+    public void updateContent(FeeUpdateContentReqDto feeUpdateContentReqDto){
+        this.paidAmount =feeUpdateContentReqDto.getPaidAmount();
+        this.paidAt =feeUpdateContentReqDto.getPaidAt();
+        this.name = feeUpdateContentReqDto.getName();
+        this.explanation = feeUpdateContentReqDto.getExplanation();
     }
 
     public void updateIsDeleted(Boolean isDeleted){

--- a/src/main/java/swm/backstage/movis/domain/fee/controller/FeeController.java
+++ b/src/main/java/swm/backstage/movis/domain/fee/controller/FeeController.java
@@ -69,8 +69,22 @@ public class FeeController {
      * */
     @PreAuthorize("hasPermission(#reqDto.feeId, 'feeId', {'ROLE_MEMBER', 'ROLE_EXECUTIVE', 'ROLE_MANAGER'})")
     @PostMapping("/explanation")
-    public FeeGetResDto createEventBillExplanation(@RequestBody @Param("reqDto") FeeCreateExplanationReqDto reqDto){
+    public FeeGetResDto createFeeExplanation(@RequestBody @Param("reqDto") FeeCreateExplanationReqDto reqDto){
         return new FeeGetResDto(feeService.createFeeExplanation(reqDto));
     }
-
+    /**
+     * 회비 수정 ( 미분류만 가능 )
+     * */
+    @PatchMapping("/content")
+    public void updateFee(@RequestParam("feeId") String feeId,
+                          @RequestBody FeeUpdateContentReqDto feeUpdateContentReqDto){
+        feeService.updateFeeContent(feeId,feeUpdateContentReqDto);
+    }
+    /**
+     * 회비 삭제
+     * */
+    @DeleteMapping()
+    public void deleteFee(@RequestParam("feeId") String feeId){
+        feeService.deleteFee(feeId);
+    }
 }

--- a/src/main/java/swm/backstage/movis/domain/fee/dto/FeeUpdateContentReqDto.java
+++ b/src/main/java/swm/backstage/movis/domain/fee/dto/FeeUpdateContentReqDto.java
@@ -1,0 +1,15 @@
+package swm.backstage.movis.domain.fee.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@NoArgsConstructor
+@Getter
+public class FeeUpdateContentReqDto {
+    private Long paidAmount;
+    private LocalDateTime paidAt;
+    private String name;
+    private String explanation;
+}

--- a/src/main/java/swm/backstage/movis/domain/fee/repository/FeeRepository.java
+++ b/src/main/java/swm/backstage/movis/domain/fee/repository/FeeRepository.java
@@ -13,33 +13,39 @@ import java.util.Optional;
 public interface FeeRepository extends JpaRepository<Fee, String> {
 
 
-    Optional<Fee> findByUlid(String id);
+    Optional<Fee> findByUlidAndIsDeleted(String id, Boolean isDeleted);
 
     // 1 회차용
     @Query("SELECT f FROM Fee f " +
             "WHERE f.event.ulid = :eventId " +
             "AND f.paidAt <= :lastPaidAt " +
+            "AND f.isDeleted = :isDeleted " +
             "ORDER BY f.ulid DESC " +
             "LIMIT :size")
     List<Fee> getFirstPage(@Param("eventId") String eventId,
                            @Param("lastPaidAt") LocalDateTime lastPaidAt,
+                           @Param("isDeleted") Boolean isDeleted,
                            @Param("size") int size);
 
     // n 회차용
     @Query("SELECT f FROM Fee f " +
             "WHERE f.event.ulid = :eventId AND f.ulid < :lastId  " +
             "AND ((f.paidAt = :lastPaidAt AND f.ulid> :lastId) OR (f.paidAt < :lastPaidAt)) " +
+            "AND f.isDeleted = :isDeleted " +
             "ORDER BY f.ulid DESC " +
             "LIMIT :size")
     List<Fee> getNextPageByEventIdAndLastId(@Param("eventId") String eventId,
                                             @Param("lastPaidAt") LocalDateTime lastPaidAt,
                                             @Param("lastId") String lastId,
+                                            @Param("isDeleted") Boolean isDeleted,
                                             @Param("size") int size);
 
     @Modifying
     @Query("UPDATE Fee f " +
             "SET f.isDeleted = :status " +
-            "WHERE f.event.ulid = :eventId ")
+            "WHERE f.event.ulid = :eventId " +
+            "AND f.isDeleted = :isDeleted ")
     int updateIsDeletedByEventId(@Param("status") Boolean status,
-                                 @Param("eventId") String eventId);
+                                 @Param("eventId") String eventId,
+                                 @Param("isDeleted") Boolean isDeleted);
 }

--- a/src/main/java/swm/backstage/movis/domain/fee/service/FeeManager.java
+++ b/src/main/java/swm/backstage/movis/domain/fee/service/FeeManager.java
@@ -16,6 +16,6 @@ public class FeeManager {
      * */
     @Transactional
     public int updateIsDeleted(String eventId){
-        return feeRepository.updateIsDeletedByEventId(Boolean.TRUE,eventId);
+        return feeRepository.updateIsDeletedByEventId(Boolean.TRUE,eventId,Boolean.FALSE);
     }
 }

--- a/src/main/java/swm/backstage/movis/domain/transaction_history/TransactionHistory.java
+++ b/src/main/java/swm/backstage/movis/domain/transaction_history/TransactionHistory.java
@@ -6,6 +6,8 @@ import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import swm.backstage.movis.domain.club.Club;
+import swm.backstage.movis.domain.event_bill.dto.EventBillUpdateContentReqDto;
+import swm.backstage.movis.domain.fee.dto.FeeUpdateContentReqDto;
 import swm.backstage.movis.domain.transaction_history.dto.TransactionHistoryCreateDto;
 import swm.backstage.movis.domain.event.Event;
 import swm.backstage.movis.domain.transaction_history.dto.TransactionStatus;
@@ -64,6 +66,20 @@ public class TransactionHistory {
     }
     public void updateIsDeleted(Boolean isDeleted){
         this.isDeleted = isDeleted;
+    }
+    public void updateContent(Object dto){
+        if(dto instanceof FeeUpdateContentReqDto){
+            FeeUpdateContentReqDto feeDto = (FeeUpdateContentReqDto) dto;
+            this.name = feeDto.getName();
+            this.paidAt = feeDto.getPaidAt();
+            this.amount = feeDto.getPaidAmount();
+        }
+        else{
+            EventBillUpdateContentReqDto eventBillDto = (EventBillUpdateContentReqDto) dto;
+            this.name = eventBillDto.getPayName();
+            this.paidAt = eventBillDto.getPaidAt();
+            this.amount = eventBillDto.getAmount();
+        }
     }
 }
 

--- a/src/main/java/swm/backstage/movis/domain/transaction_history/repository/TransactionHistoryRepository.java
+++ b/src/main/java/swm/backstage/movis/domain/transaction_history/repository/TransactionHistoryRepository.java
@@ -40,32 +40,38 @@ public interface TransactionHistoryRepository extends JpaRepository<TransactionH
     @Query("SELECT th FROM TransactionHistory th " +
             "WHERE th.club.ulid = :clubId " +
             "AND th.paidAt <= :lastPaidAt " +
+            "AND th.isDeleted = :isDeleted " +
             "ORDER BY th.paidAt DESC, th.ulid ASC " +
             "LIMIT :size")
     List<TransactionHistory> getFirstPageByClub(@Param("clubId") String clubId,
-                                                 @Param("lastPaidAt") LocalDateTime lastPaidAt,
-                                                 @Param("size") int size);
+                                                @Param("lastPaidAt") LocalDateTime lastPaidAt,
+                                                @Param("isDeleted") Boolean isDeleted,
+                                                @Param("size") int size);
 
     // n 회차용 Club으로 조회
     @Query("SELECT th FROM TransactionHistory th " +
             "WHERE th.club.ulid = :clubId " +
             "AND ((th.paidAt = :lastPaidAt AND th.ulid > :lastId) OR (th.paidAt < :lastPaidAt)) " +
+            "AND th.isDeleted = :isDeleted " +
             "ORDER BY th.paidAt DESC , th.ulid ASC " +
             "LIMIT :size")
     List<TransactionHistory> getNextPageByClub(@Param("clubId") String clubId,
                                                 @Param("lastPaidAt") LocalDateTime lastPaidAt,
                                                 @Param("lastId") String lastId,
+                                                @Param("isDeleted") Boolean isDeleted,
                                                 @Param("size") int size);
 
     @Modifying
     @Query("UPDATE TransactionHistory t " +
             "SET t.isDeleted = :status " +
-            "WHERE t.event.ulid = :eventId ")
+            "WHERE t.event.ulid = :eventId " +
+            "AND t.isDeleted = :isDeleted")
     int updateIsDeletedByEventId(@Param("status") Boolean status,
-                                 @Param("eventId") String eventId);
+                                 @Param("eventId") String eventId,
+                                 @Param("isDeleted") Boolean isDeleted);
 
     Optional<TransactionHistory> findByElementUlid(String elementUlid);
-    List<TransactionHistory> findAllByClubUlidAndIsClassifiedOrderByPaidAtDesc(String clubId, boolean isClassified);
-    Long countByClubUlidAndIsClassified(String clubId, boolean isClassified);
+    List<TransactionHistory> findAllByClubUlidAndIsClassifiedAndIsDeletedOrderByPaidAtDesc(String clubId, boolean isClassified, boolean isDeleted);
+    Long countByClubUlidAndIsClassifiedAndIsDeleted(String clubId, boolean isClassified, boolean isDeleted);
 
 }

--- a/src/main/java/swm/backstage/movis/domain/transaction_history/service/TransactionHistoryManager.java
+++ b/src/main/java/swm/backstage/movis/domain/transaction_history/service/TransactionHistoryManager.java
@@ -16,6 +16,6 @@ public class TransactionHistoryManager {
      * */
     @Transactional
     public int updateIsDeleted(String eventId){
-        return transactionHistoryRepository.updateIsDeletedByEventId(Boolean.TRUE,eventId);
+        return transactionHistoryRepository.updateIsDeletedByEventId(Boolean.TRUE,eventId,Boolean.FALSE);
     }
 }

--- a/src/main/java/swm/backstage/movis/domain/transaction_history/service/TransactionHistoryService.java
+++ b/src/main/java/swm/backstage/movis/domain/transaction_history/service/TransactionHistoryService.java
@@ -25,6 +25,10 @@ public class TransactionHistoryService {
     private final TransactionHistoryRepository transactionHistoryRepository;
     private final EventService eventService;
     private final ClubService clubService;
+
+    public TransactionHistory getTransactionHistory(String elementId){
+        return transactionHistoryRepository.findByElementUlid(elementId).orElseThrow(()->new BaseException("해당 거래내역이 존재하지 않습니다.",ErrorCode.ELEMENT_NOT_FOUND));
+    }
     /**
      * 거래내역 저장
      */
@@ -52,7 +56,6 @@ public class TransactionHistoryService {
         }
         return new TransactionHistoryGetPagingListResDto(transactionHistoryListList, isLast, null);
     }
-
     /**
      * 전체 거래내역 페이징 (Club 으로)
      */
@@ -62,11 +65,11 @@ public class TransactionHistoryService {
 
 
         if (lastId.equals("first")) {
-            transactionHistoryListList = transactionHistoryRepository.getFirstPageByClub(club.getUlid(), lastPaidAt, size + 1);
+            transactionHistoryListList = transactionHistoryRepository.getFirstPageByClub(club.getUlid(), lastPaidAt, Boolean.FALSE,size + 1);
         } else {
             TransactionHistory transactionHistory = transactionHistoryRepository.findByUlid(lastId)
                     .orElseThrow(() -> new BaseException("TransactionHistory is not found", ErrorCode.ELEMENT_NOT_FOUND));
-            transactionHistoryListList = transactionHistoryRepository.getNextPageByClub(club.getUlid(), lastPaidAt, transactionHistory.getElementUlid(), size + 1);
+            transactionHistoryListList = transactionHistoryRepository.getNextPageByClub(club.getUlid(), lastPaidAt, transactionHistory.getElementUlid(), Boolean.FALSE,size + 1);
         }
 
         //하나 추가해서 조회한거 삭제해주기
@@ -88,12 +91,12 @@ public class TransactionHistoryService {
      * 미분류 리스트 조회 ( not 페이징 )
      * */
     public List<TransactionHistory> getUnclassifiedTransactionHistory(String clubId) {
-        return transactionHistoryRepository.findAllByClubUlidAndIsClassifiedOrderByPaidAtDesc(clubId,false);
+        return transactionHistoryRepository.findAllByClubUlidAndIsClassifiedAndIsDeletedOrderByPaidAtDesc(clubId,false,false);
     }
     /**
      *  미분류 개수 조회
      * */
     public Long getTransactionHistoryCount(String clubId) {
-        return transactionHistoryRepository.countByClubUlidAndIsClassified(clubId,false);
+        return transactionHistoryRepository.countByClubUlidAndIsClassifiedAndIsDeleted(clubId,false,false);
     }
 }

--- a/src/main/java/swm/backstage/movis/global/error/ErrorCode.java
+++ b/src/main/java/swm/backstage/movis/global/error/ErrorCode.java
@@ -22,7 +22,8 @@ public enum ErrorCode {
     UNAUTHORIZED_PERMISSION("C011", "Unauthorized Permission", DisplayType.POPUP),
     UNAUTHENTICATED_REQUEST("C012", "Unauthenticated Request", DisplayType.POPUP),
     DECRYPTION_FAILED("C013", "Decryption Failed", DisplayType.POPUP),
-    DUPLICATE_CLUB_USER("C014", "Duplicate ClubUser", DisplayType.POPUP);
+    DUPLICATE_CLUB_USER("C014", "Duplicate ClubUser", DisplayType.POPUP),
+    CLASSIFIED_ERROR("C015", "Classified", DisplayType.POPUP);
 
     private final String code;
     private final String message;

--- a/src/test/java/swm/backstage/movis/multi/EventTest.java
+++ b/src/test/java/swm/backstage/movis/multi/EventTest.java
@@ -15,6 +15,7 @@ import swm.backstage.movis.domain.club.dto.ClubCreateReqDto;
 import swm.backstage.movis.domain.club.service.ClubService;
 import swm.backstage.movis.domain.event.Event;
 import swm.backstage.movis.domain.event.dto.EventCreateReqDto;
+import swm.backstage.movis.domain.event.service.EventManager;
 import swm.backstage.movis.domain.event.service.EventService;
 import swm.backstage.movis.domain.event_bill.dto.EventBillInputReqDto;
 import swm.backstage.movis.domain.event_bill.service.EventBillService;
@@ -62,6 +63,9 @@ public class EventTest {
 
     @Autowired
     private EventMemberService eventMemberService;
+
+    @Autowired
+    private EventManager eventManager;
 
     private String clubId;
     private String eventId;
@@ -126,7 +130,7 @@ public class EventTest {
                 try{
                     countDownLatch.await();
                     log.info("Thread start");
-                    eventService.deleteEvent(clubId,eventId);
+                    eventManager.deleteEvent(clubId,eventId);
                 }
                 catch(BaseException e){
                     log.info(e.getErrorCode().toString());


### PR DESCRIPTION

# 이슈
- #91 

# 구현 기능

## 1. Fee, Bill, transactionHistory ( 수정, 삭제, 조회로직 변경)

개별 Fee, Bill 수정하면 transactionHistory도 수정해야함

### Fee 수정 ( 분류된 것만)
patch /api/v1/fees/content

1. account book 원래 금액 차감, 수정 금액 추가
2. transactionHistory amount, paidAt, name 수정사항 반영
3. fee 변경사항 반영

###Fee 삭제
delete /api/v1/fees

fee isDeleted 처리 및 transactionHistory isDeleted 처리하기

### Fee 관련 조회 
isDeleted = false만 조회되도록 수정


### EventBill 수정, 삭제
-> Fee와 로직 동일하게 작성

### 조회로직 변경
-> 모든 쿼리에 isDeleted = false 조건으로 조회하도록 수정


## 2. Club 삭제, 조회로직 변경

일단 club 만 isDeleted처리되도록 로직 구성
이유는 club에 관한 접근이 불가능하면 다른 모든 기능들을 사용할 수 없기 때문에 club만 isDeleted 처리하도록 구성하였습니다.

조회같은경우 isDeleted되면 조회되지 않도록 수정하였습니다.

