### PR TITLE
[feat] issue-#95: 사용자 정보 조회 API 구현 완료

### DIFF
--- a/src/main/java/swm/backstage/movis/domain/user/controlloer/UserController.java
+++ b/src/main/java/swm/backstage/movis/domain/user/controlloer/UserController.java
@@ -1,9 +1,27 @@
 package swm.backstage.movis.domain.user.controlloer;
 
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import swm.backstage.movis.domain.auth.dto.AuthenticationPrincipalDetails;
+import swm.backstage.movis.domain.user.dto.response.UserGetResDto;
+import swm.backstage.movis.domain.user.service.UserService;
+import swm.backstage.movis.global.error.ErrorCode;
+import swm.backstage.movis.global.error.exception.BaseException;
 
 @RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/users")
 public class UserController {
 
+    private final UserService userService;
 
+    @GetMapping("/me")
+    public UserGetResDto getUserByToken(@AuthenticationPrincipal AuthenticationPrincipalDetails principal){
+
+        return new UserGetResDto(userService.findByIdentifier(principal.getIdentifier())
+                .orElseThrow(()-> new BaseException("Element Not Found", ErrorCode.ELEMENT_NOT_FOUND)));
+    }
 }

--- a/src/main/java/swm/backstage/movis/domain/user/dto/response/UserGetResDto.java
+++ b/src/main/java/swm/backstage/movis/domain/user/dto/response/UserGetResDto.java
@@ -1,0 +1,20 @@
+package swm.backstage.movis.domain.user.dto.response;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import swm.backstage.movis.domain.user.User;
+
+@Getter
+@NoArgsConstructor
+public class UserGetResDto {
+
+    private String identifier;
+    private String name;
+    private String phoneNo;
+
+    public UserGetResDto(User user) {
+        this.identifier = user.getIdentifier();
+        this.name = user.getName();
+        this.phoneNo = user.getPhoneNo();
+    }
+}


### PR DESCRIPTION
# 이슈
- [사용자 정보 조회 기능 #95
](https://github.com/swm-backstage/movis-backend/issues/95)

# 구현 기능
- controller 메서드 getUserByToken 구현
API경로의 경우 카카오 OAuth2.0의 공식 문서에서 참고하여 ".../users/me"와 같이 설정함
https://developers.kakao.com/docs/latest/ko/kakaologin/rest-api#req-user-info
- service는 기존 club을 위해 구현된 메서드 이용

# 작업 시간
40m
